### PR TITLE
feat/ksh/API-스펙-정의-(Attempt-기반-조회)

### DIFF
--- a/QuizHistory.md
+++ b/QuizHistory.md
@@ -26,10 +26,42 @@
 - 이유: 제출 데이터 기반으로 화면에 보여줄 결과 정리
 
 ## 결정사항
-- 아직 없음
+- 1단계 Read API는 `attempt` 기반 조회로 확정
+- 사이드프로젝트 범위에서는 attempt 소유자 권한 검증은 제외
 
 ## API / DTO 설계 기록
-- 아직 없음
+- [CONFIRMED] 1. 문제/보기 조회 (Read, Attempt 기반)
+  - Endpoint: `GET /api/quiz/attempts/{attemptId}/questions/{seq}`
+  - Path Variables:
+    - `attemptId`: 퀴즈 시도 ID
+    - `seq`: 현재 문제 번호(1부터 시작)
+  - 동작 규칙:
+    - 해당 `attemptId`의 `seq` 문제 1개를 반환
+    - 보기 순서는 `quiz_attempt_questions.choice_order` 기준으로 고정 반환 (QUIZ-A03/A04)
+    - 제출 전 조회에서는 정답/해설/정오답 필드를 반환하지 않음 (QUIZ-A05)
+  - Response (ApiResponse):
+    - `data.attemptId`
+    - `data.seq`
+    - `data.totalQuestions`
+    - `data.questionId`
+    - `data.questionText` (실제 회화 문제 문장)
+    - `data.scene`:
+      - `sceneId`
+      - `name`
+      - `description`
+    - `data.choices[]`:
+      - `choiceId`
+      - `choiceText`
+      - `order`
+    - 제외 필드:
+      - `isCorrect`
+      - `correctAnswer`
+      - `explanation`
+  - Error Cases:
+    - `404 ATTEMPT_NOT_FOUND`: attempt 없음
+    - `404 QUESTION_NOT_FOUND`: 해당 seq 문제 없음
+  - 참고:
+    - 본 프로젝트 범위에서는 `403 FORBIDDEN (attempt 소유자 검증)`은 이번 단계에서 적용하지 않음
 
 ## DB 매핑 메모
 - 아직 없음

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/QuizChoiceResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/QuizChoiceResponse.java
@@ -1,0 +1,43 @@
+package com.team.jpquiz.quiz.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class QuizChoiceResponse {
+
+    @JsonIgnore
+    private Long questionId; // 이 보기가 어느 문제 소속인지 연결키
+    private Long choiceId; // 보기 Pk
+    private String choiceText; // 보기 문장
+
+    // Mybatis가 객체 생성할 때 기본 생성자가 필요
+    public QuizChoiceResponse(){
+
+    }
+    public QuizChoiceResponse(Long questionId, Long choiceId, String choiceText) {
+        this.questionId = questionId;
+        this.choiceId = choiceId;
+        this.choiceText = choiceText;
+    }
+
+    public Long getQuestionId(){
+        return questionId;
+    }
+    public void setQuestionId(Long questionId) {
+        this.questionId = questionId;
+    }
+    public Long getChoiceId() {
+        return choiceId;
+    }
+    public void setChoiceId(Long choiceId) {
+        this.choiceId = choiceId;
+    }
+    public String getChoiceText() {
+        return choiceText;
+    }
+    public void setChoiceText(String choiceText) {
+        this.choiceText = choiceText;
+    }
+
+}
+
+

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/QuizQuestionResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/QuizQuestionResponse.java
@@ -1,0 +1,46 @@
+package com.team.jpquiz.quiz.dto.response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuizQuestionResponse {
+
+    private Long questionId; // 문제 PK
+    private String questionText; // 문제 문장
+    private Long sceneId; // 상황별
+
+    // 이 문제의 보기 목록
+    // null 방지 위해 빈 리스트로 ㅊ초기화
+    private List<QuizChoiceResponse> choices = new ArrayList<>();
+    public QuizQuestionResponse(){
+    }
+    public QuizQuestionResponse(Long questionId, String questionText, Long sceneId) {
+        this.questionId = questionId;
+        this.questionText = questionText;
+        this.sceneId = sceneId;
+    }
+    public Long getQuestionId() {
+        return questionId;
+    }
+    public void setQuestionId(Long questionId) {
+        this.questionId = questionId;
+    }
+    public String getQuestionText() {
+        return questionText;
+    }
+    public void setQuestionText(String questionText){
+        this.questionText = questionText;
+    }
+    public Long getSceneId(){
+        return sceneId;
+    }
+    public void setSceneId(Long sceneId){
+        this.sceneId = sceneId;
+    }
+    public List<QuizChoiceResponse> getChoices(){
+        return choices;
+    }
+    public void setChoices(List<QuizChoiceResponse> choices) {
+        this.choices = choices;
+    }
+}

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/QuizQuestionsResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/QuizQuestionsResponse.java
@@ -1,0 +1,23 @@
+package com.team.jpquiz.quiz.dto.response;
+
+import org.springframework.security.core.parameters.P;
+
+import java.util.List;
+
+public class QuizQuestionsResponse {
+    // 응답 스펙 : questions[]
+    private List<QuizQuestionResponse> questions;
+
+    public QuizQuestionsResponse(){
+    }
+
+    public QuizQuestionsResponse(List<QuizQuestionResponse> questions) {
+        this.questions = questions;
+    }
+    public List<QuizQuestionResponse> getQuestions() {
+        return questions;
+    }
+    public void setQuestions(List<QuizQuestionResponse> questions) {
+        this.questions = questions;
+    }
+}

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/QuizSceneResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/QuizSceneResponse.java
@@ -1,0 +1,8 @@
+package com.team.jpquiz.quiz.dto.response;
+
+public class QuizSceneResponse {
+    Long sceneId;
+    String name;
+    String description;
+
+}


### PR DESCRIPTION
- Quiz Read API 스펙 확정
- GET /api/quiz/attempts/{attemptId}/questions/{seq}
- choice_order 고정
- 제출 전 정답/해설/정오답 미반환