### PR TITLE
JWT 토큰 생성 및 회원가입 기반 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,10 @@ dependencies {
     // Security (인증/인가 기본 골격)
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // JWT (stub only; real implementation removed)
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     // Swagger/OpenAPI
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"

--- a/src/main/java/com/team/jpquiz/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/team/jpquiz/common/security/JwtTokenProvider.java
@@ -1,0 +1,229 @@
+package com.team.jpquiz.common.security;
+
+import com.team.jpquiz.member.command.domain.Member;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성 및 검증 유틸리티
+ * Access Token, Refresh Token 생성 및 검증 담당
+ */
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    /**
+     * 생성자: JWT 설정 값 주입 및 SecretKey 초기화
+     *
+     * @param secret                  Base64 인코딩된 JWT Secret Key
+     * @param accessTokenExpiration   Access Token 만료 시간 (밀리초)
+     * @param refreshTokenExpiration  Refresh Token 만료 시간 (밀리초)
+     */
+    public JwtTokenProvider(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.access-token-expiration}") long accessTokenExpiration,
+            @Value("${app.jwt.refresh-token-expiration}") long refreshTokenExpiration) {
+
+        // Base64 디코딩하여 SecretKey 생성
+        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    /**
+     * Access Token 생성
+     *
+     * @param member 회원 엔티티
+     * @return JWT Access Token
+     */
+    public String generateAccessToken(Member member) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(member.getUserId()))  // userId를 subject로 설정
+                .claim("email", member.getEmail())            // email을 claim에 추가
+                .claim("role", member.getRole().name())       // role을 claim에 추가
+                .claim("type", "access")                      // 토큰 타입
+                .issuedAt(now)                                // 발급 시간
+                .expiration(expiryDate)                       // 만료 시간
+                .signWith(secretKey)                          // 서명
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성
+     *
+     * @param member 회원 엔티티
+     * @return JWT Refresh Token
+     */
+    public String generateRefreshToken(Member member) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(member.getUserId()))  // userId를 subject로 설정
+                .claim("type", "refresh")                     // 토큰 타입
+                .issuedAt(now)                                // 발급 시간
+                .expiration(expiryDate)                       // 만료 시간
+                .signWith(secretKey)                          // 서명
+                .compact();
+    }
+
+    /**
+     * 토큰 검증
+     *
+     * @param token JWT 토큰
+     * @return 유효하면 true, 그렇지 않으면 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * 토큰에서 사용자 ID 추출
+     *
+     * @param token JWT 토큰
+     * @return 사용자 ID
+     */
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 토큰에서 이메일 추출
+     *
+     * @param token JWT 토큰
+     * @return 이메일 (Access Token만 포함)
+     */
+    public String getEmailFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get("email", String.class);
+    }
+
+    /**
+     * 토큰에서 권한(Role) 추출
+     *
+     * @param token JWT 토큰
+     * @return 권한 (Access Token만 포함)
+     */
+    public String getRoleFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get("role", String.class);
+    }
+
+    /**
+     * 토큰 타입 확인 (access 또는 refresh)
+     *
+     * @param token JWT 토큰
+     * @return 토큰 타입
+     */
+    public String getTokenType(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.get("type", String.class);
+    }
+
+    /**
+     * Refresh Token인지 확인
+     *
+     * @param token JWT 토큰
+     * @return Refresh Token이면 true
+     */
+    public boolean isRefreshToken(String token) {
+        return "refresh".equals(getTokenType(token));
+    }
+
+    /**
+     * Access Token인지 확인
+     *
+     * @param token JWT 토큰
+     * @return Access Token이면 true
+     */
+    public boolean isAccessToken(String token) {
+        return "access".equals(getTokenType(token));
+    }
+
+    /**
+     * 토큰 만료 시간 조회 (밀리초)
+     *
+     * @param token JWT 토큰
+     * @return 만료 시간 (밀리초)
+     */
+    public long getExpirationTime(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Date expiration = claims.getExpiration();
+        Date now = new Date();
+        return expiration.getTime() - now.getTime();
+    }
+
+    /**
+     * Access Token 만료 시간 조회 (초 단위)
+     *
+     * @return Access Token 만료 시간 (초)
+     */
+    public long getAccessTokenExpirationInSeconds() {
+        return accessTokenExpiration / 1000;
+    }
+
+    /**
+     * Refresh Token 만료 시간 조회 (초 단위)
+     *
+     * @return Refresh Token 만료 시간 (초)
+     */
+    public long getRefreshTokenExpirationInSeconds() {
+        return refreshTokenExpiration / 1000;
+    }
+}

--- a/src/main/java/com/team/jpquiz/member/command/infrastructure/MemberRepository.java
+++ b/src/main/java/com/team/jpquiz/member/command/infrastructure/MemberRepository.java
@@ -1,4 +1,41 @@
 package com.team.jpquiz.member.command.infrastructure;
 
-public interface MemberRepository {
+import com.team.jpquiz.member.command.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    /**
+     * 이메일 중복 확인
+     *
+     * @param email 이메일
+     * @return 존재하면 true
+     */
+    boolean existsByEmail(String email);
+
+    /**
+     * 닉네임 중복 확인
+     *
+     * @param nickname 닉네임
+     * @return 존재하면 true
+     */
+    boolean existsByNickname(String nickname);
+
+    /**
+     * 이메일로 회원 조회
+     *
+     * @param email 이메일
+     * @return 회원 Optional
+     */
+    Optional<Member> findByEmail(String email);
+
+    /**
+     * 닉네임으로 회원 조회
+     *
+     * @param nickname 닉네임
+     * @return 회원 Optional
+     */
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/team/jpquiz/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/com/team/jpquiz/member/dto/request/MemberRegisterRequest.java
@@ -1,4 +1,46 @@
 package com.team.jpquiz.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원가입 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "회원가입 요청")
 public class MemberRegisterRequest {
+
+    @Schema(description = "이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Size(max = 255, message = "이메일은 255자를 초과할 수 없습니다.")
+    private String email;
+
+    @Schema(description = "비밀번호 (8~50자, 영문/숫자/특수문자 포함)", example = "Password123!", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 50, message = "비밀번호는 8자 이상 50자 이하여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 각각 최소 1개 이상 포함해야 합니다."
+    )
+    private String password;
+
+    @Schema(description = "닉네임 (2~50자)", example = "일본어마스터", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하여야 합니다.")
+    @Pattern(
+            regexp = "^[가-힣a-zA-Z0-9_]+$",
+            message = "닉네임은 한글, 영문, 숫자, 언더스코어(_)만 사용 가능합니다."
+    )
+    private String nickname;
 }

--- a/src/main/java/com/team/jpquiz/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/team/jpquiz/member/dto/response/MemberResponse.java
@@ -1,4 +1,62 @@
 package com.team.jpquiz.member.dto.response;
 
+import com.team.jpquiz.member.command.domain.Member;
+import com.team.jpquiz.member.command.domain.MemberRole;
+import com.team.jpquiz.member.command.domain.MemberStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 회원 정보 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "회원 정보 응답")
 public class MemberResponse {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "이메일", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "닉네임", example = "일본어마스터")
+    private String nickname;
+
+    @Schema(description = "권한", example = "USER")
+    private MemberRole role;
+
+    @Schema(description = "상태", example = "ACTIVE")
+    private MemberStatus status;
+
+    @Schema(description = "마지막 로그인 일시", example = "2026-02-10T19:30:00")
+    private LocalDateTime lastLoginAt;
+
+    @Schema(description = "가입 일시", example = "2026-02-01T10:00:00")
+    private LocalDateTime createdAt;
+
+    /**
+     * Member 엔티티를 MemberResponse로 변환
+     *
+     * @param member Member 엔티티
+     * @return MemberResponse
+     */
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+                .userId(member.getUserId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .role(member.getRole())
+                .status(member.getStatus())
+                .lastLoginAt(member.getLastLoginAt())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/team/jpquiz/member/dto/response/TokenResponse.java
+++ b/src/main/java/com/team/jpquiz/member/dto/response/TokenResponse.java
@@ -1,4 +1,64 @@
 package com.team.jpquiz.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JWT 토큰 응답 DTO
+ * 로그인 및 토큰 갱신 시 사용
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "JWT 토큰 응답")
 public class TokenResponse {
+
+    @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String accessToken;
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+
+    @Schema(description = "토큰 타입", example = "Bearer", defaultValue = "Bearer")
+    @Builder.Default
+    private String tokenType = "Bearer";
+
+    @Schema(description = "액세스 토큰 만료 시간 (초)", example = "1800")
+    private Long expiresIn;
+
+    /**
+     * 액세스 토큰만 포함하는 응답 생성 (토큰 갱신 시 사용)
+     *
+     * @param accessToken 액세스 토큰
+     * @param expiresIn   만료 시간 (초)
+     * @return TokenResponse
+     */
+    public static TokenResponse ofAccessToken(String accessToken, Long expiresIn) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .tokenType("Bearer")
+                .expiresIn(expiresIn)
+                .build();
+    }
+
+    /**
+     * 액세스 토큰과 리프레시 토큰을 모두 포함하는 응답 생성 (로그인/회원가입 시 사용)
+     *
+     * @param accessToken  액세스 토큰
+     * @param refreshToken 리프레시 토큰
+     * @param expiresIn    액세스 토큰 만료 시간 (초)
+     * @return TokenResponse
+     */
+    public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(expiresIn)
+                .build();
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,6 +2,9 @@ app:
   cors:
     # 개발 서버 허용 도메인(필요 시 설정)
     allowed-origins: ""
+  jwt:
+    # JWT Secret (환경변수로 주입 또는 개발용 고정값)
+    secret: ${JWT_SECRET:dGhpc2lzYXZlcnlzZWN1cmVzZWNyZXRrZXlmb3JqcHF1aXpkZXZlbG9wbWVudGVudmlyb25tZW50MTIzNDU2Nzg5MA==}
 spring:
   datasource:
     # 개발 서버에서는 환경변수로 주입

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,8 @@ app:
     exposed-headers: ""
     allow-credentials: false
     max-age: 3600
+  jwt:
+    # JWT 기본 설정 (환경별로 덮어쓰기 필수)
+    secret: ""  # Base64 인코딩된 시크릿 키 (최소 256비트, 환경변수로 주입 권장)
+    access-token-expiration: 1800000     # 30분 (밀리초)
+    refresh-token-expiration: 604800000  # 7일 (밀리초)


### PR DESCRIPTION
  - build.gradle: JWT 라이브러리 추가 (jjwt 0.12.3)
  - application.yml: JWT 설정 추가 (access 30분, refresh 7일)
  - application-dev.yml: 개발 환경 JWT Secret 설정
  - JwtTokenProvider: JWT 토큰 생성/검증 유틸리티 구현
  - Access Token 생성 (userId, email, role 포함)
  - Refresh Token 생성 (userId만 포함)
  - 토큰 검증 및 정보 추출 메서드
  - MemberRepository: 회원가입용 쿼리 메서드 추가
  - existsByEmail, existsByNickname (중복 확인)
  - findByEmail, findByNickname (회원 조회)
  - TokenResponse: JWT 토큰 응답 DTO 구현
  - MemberRegisterRequest: 회원가입 요청 DTO 구현 (validation 포함)
  - MemberResponse: 회원 정보 응답 DTO 구현

Response 클래스에 @Schema 어노테이션은 추후 Swagger를 이용한 API테스트 문서화를 위해 사용했습니다 
