### PR TITLE
[feat] 오답노트 기능 하드코딩 수정

### DIFF
--- a/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerCommandController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerCommandController.java
@@ -15,20 +15,24 @@ public class WrongAnswerCommandController {
 
   // 오답 수동 저장 (테스트용)
   @PostMapping
-  public ResponseEntity<Void> saveWrongAnswer(@RequestBody WrongAnswerSaveRequest request) {
-    // TODO: 추후 인증된 사용자 ID로 변경 필요 (@AuthenticationPrincipal)
-    Long currentMemberId = 1L;
-
+  public ResponseEntity<Void> saveWrongAnswer(
+      // 임시 학습용 사용자 식별 방식입니다.
+      // TODO: 추후 @AuthenticationPrincipal 기반 인증 사용자 주입으로 교체합니다.
+      @RequestHeader("X-Member-Id") Long currentMemberId,
+      @RequestBody WrongAnswerSaveRequest request
+  ) {
     wrongAnswerCommandService.saveWrongAnswer(currentMemberId, request);
     return ResponseEntity.ok().build();
   }
 
   // 오답 삭제
   @DeleteMapping("/{questionId}")
-  public ResponseEntity<Void> deleteWrongAnswer(@PathVariable Long questionId) {
-    // TODO: 추후 인증된 사용자 ID로 변경 필요
-    Long currentMemberId = 1L;
-
+  public ResponseEntity<Void> deleteWrongAnswer(
+      // 임시 학습용 사용자 식별 방식입니다.
+      // TODO: 추후 @AuthenticationPrincipal 기반 인증 사용자 주입으로 교체합니다.
+      @RequestHeader("X-Member-Id") Long currentMemberId,
+      @PathVariable Long questionId
+  ) {
     wrongAnswerCommandService.deleteWrongAnswer(currentMemberId, questionId);
     return ResponseEntity.noContent().build(); // 204 No Content 반환
   }

--- a/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerQueryController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerQueryController.java
@@ -7,6 +7,7 @@ import com.team.jpquiz.quiz.query.application.WrongAnswerQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,12 +20,12 @@ public class WrongAnswerQueryController {
 
   @GetMapping
   public ApiResponse<PageResponse<WrongAnswerResponse>> getWrongAnswerList(
+      // 임시 학습용 사용자 식별 방식입니다.
+      // TODO: 추후 @AuthenticationPrincipal 기반 인증 사용자 주입으로 교체합니다.
+      @RequestHeader("X-Member-Id") Long currentMemberId,
       @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "10") int size
   ) {
-    // TODO: 추후 인증된 사용자 ID로 변경 필요
-    Long currentMemberId = 1L;
-
     PageResponse<WrongAnswerResponse> response = wrongAnswerQueryService.getWrongAnswerList(currentMemberId, page, size);
     return ApiResponse.success(response);
   }


### PR DESCRIPTION
 ## 작업 내용

  - 오답노트 API의 사용자 식별 하드코딩(currentMemberId = 1L)을 제거하고, 요청 헤더 기반 사용자 식별 방식으로 전환했습니다.
  - 추후 실무 인증 방식으로 교체할 수 있도록 TODO 주석을 추가했습니다.

  ## 상세 변경 사항

  - 수정 파일:
      - src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerCommandController.java
      - src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerQueryController.java
  - 변경 로직:
      - saveWrongAnswer, deleteWrongAnswer, getWrongAnswerList 메서드 파라미터에 @RequestHeader("X-Member-Id") Long currentMemberId를 추가했습니다.
      - 기존 메서드 내부의 Long currentMemberId = 1L; 하드코드 라인을 삭제했습니다.
      - 각 위치에 TODO: 추후 @AuthenticationPrincipal 기반 인증 사용자 주입으로 교체 주석을 추가했습니다.
  - 주의 포인트:
      - 현재 방식은 학습/임시 방식이며, 운영 환경에서는 헤더 위변조 가능성이 있으므로 반드시 인증 컨텍스트 기반으로 교체해야 합니다.


  ## 관련 이슈

  - FeatureRequirements quizwr-01 진행 중
  - FeatureRequirements quizwr-02 진행 중