### PR TITLE
로그인 기능 구현

### DIFF
--- a/src/main/java/com/team/jpquiz/auth/presentation/AuthController.java
+++ b/src/main/java/com/team/jpquiz/auth/presentation/AuthController.java
@@ -1,0 +1,100 @@
+package com.team.jpquiz.auth.presentation;
+
+import com.team.jpquiz.common.dto.ApiResponse;
+import com.team.jpquiz.member.command.application.MemberCommandService;
+import com.team.jpquiz.member.dto.request.MemberLoginRequest;
+import com.team.jpquiz.member.dto.request.MemberRegisterRequest;
+import com.team.jpquiz.member.dto.response.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 인증 관련 API 컨트롤러
+ * 회원가입, 로그인, 토큰 갱신 등
+ */
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final MemberCommandService memberCommandService;
+
+    /**
+     * 회원가입 API
+     *
+     * @param request 회원가입 요청 DTO
+     * @return JWT 토큰 응답
+     */
+    @Operation(summary = "회원가입", description = "새로운 회원을 등록하고 JWT 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (유효성 검사 실패)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이메일 또는 닉네임 중복"
+            )
+    })
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<TokenResponse>> register(
+            @Valid @RequestBody MemberRegisterRequest request
+    ) {
+        TokenResponse tokenResponse = memberCommandService.register(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.ok("회원가입이 완료되었습니다.", tokenResponse));
+    }
+
+    /**
+     * 로그인 API
+     *
+     * @param request 로그인 요청 DTO
+     * @return JWT 토큰 응답
+     */
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT 토큰을 발급합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (이메일 또는 비밀번호 불일치)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "비활성화된 계정"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원을 찾을 수 없음"
+            )
+    })
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
+            @Valid @RequestBody MemberLoginRequest request
+    ) {
+        TokenResponse tokenResponse = memberCommandService.login(request);
+        return ResponseEntity
+                .ok(ApiResponse.ok("로그인이 완료되었습니다.", tokenResponse));
+    }
+}

--- a/src/main/java/com/team/jpquiz/global/error/ErrorCode.java
+++ b/src/main/java/com/team/jpquiz/global/error/ErrorCode.java
@@ -3,11 +3,21 @@ package com.team.jpquiz.global.error;
 import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
+    // Common
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "요청이 올바르지 않습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다.");
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다."),
+
+    // Auth
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "회원을 찾을 수 없습니다."),
+    INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "INACTIVE_MEMBER", "비활성화된 계정입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/team/jpquiz/member/command/application/MemberCommandService.java
+++ b/src/main/java/com/team/jpquiz/member/command/application/MemberCommandService.java
@@ -1,4 +1,108 @@
 package com.team.jpquiz.member.command.application;
 
+import com.team.jpquiz.common.security.JwtTokenProvider;
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
+import com.team.jpquiz.member.command.domain.Member;
+import com.team.jpquiz.member.command.infrastructure.MemberRepository;
+import com.team.jpquiz.member.dto.request.MemberLoginRequest;
+import com.team.jpquiz.member.dto.request.MemberRegisterRequest;
+import com.team.jpquiz.member.dto.response.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원 Command 서비스
+ * 회원가입, 정보 수정, 탈퇴 등 상태 변경 작업 담당
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class MemberCommandService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 회원가입
+     *
+     * @param request 회원가입 요청 DTO
+     * @return JWT 토큰 응답
+     */
+    public TokenResponse register(MemberRegisterRequest request) {
+        // 1. 이메일 중복 검사
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 2. 닉네임 중복 검사
+        if (memberRepository.existsByNickname(request.getNickname())) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        // 3. 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        // 4. 회원 엔티티 생성
+        Member member = Member.create(
+                request.getEmail(),
+                encodedPassword,
+                request.getNickname()
+        );
+
+        // 5. 회원 저장
+        Member savedMember = memberRepository.save(member);
+        log.info("회원가입 완료: userId={}, email={}", savedMember.getUserId(), savedMember.getEmail());
+
+        // 6. JWT 토큰 생성 및 반환
+        String accessToken = jwtTokenProvider.generateAccessToken(savedMember);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(savedMember);
+
+        return TokenResponse.of(
+                accessToken,
+                refreshToken,
+                jwtTokenProvider.getAccessTokenExpirationInSeconds()
+        );
+    }
+
+    /**
+     * 로그인
+     *
+     * @param request 로그인 요청 DTO
+     * @return JWT 토큰 응답
+     */
+    public TokenResponse login(MemberLoginRequest request) {
+        // 1. 이메일로 회원 조회
+        Member member = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 3. 계정 상태 확인 (활성 상태인지)
+        if (!member.isActive()) {
+            throw new CustomException(ErrorCode.INACTIVE_MEMBER);
+        }
+
+        // 4. 마지막 로그인 시각 업데이트
+        member.updateLastLoginAt();
+        log.info("로그인 성공: userId={}, email={}", member.getUserId(), member.getEmail());
+
+        // 5. JWT 토큰 생성 및 반환
+        String accessToken = jwtTokenProvider.generateAccessToken(member);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(member);
+
+        return TokenResponse.of(
+                accessToken,
+                refreshToken,
+                jwtTokenProvider.getAccessTokenExpirationInSeconds()
+        );
+    }
 }

--- a/src/main/java/com/team/jpquiz/member/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/team/jpquiz/member/dto/request/MemberLoginRequest.java
@@ -1,4 +1,27 @@
 package com.team.jpquiz.member.dto.request;
 
-public class MemberLoginRequest {
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "로그인 요청")
+public class MemberLoginRequest{
+
+    @Schema(description = "이메일", example = "user@example.com")
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(description = "비밀번호", example = "password123!")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
 }


### PR DESCRIPTION
feat: 로그인 기능 구현

  구현
  - 이메일/비밀번호 기반 로그인 기능 구현
  - 로그인 성공 시 JWT Access/Refresh Token 발급
  - 인증 관련 에러 코드 추가 (MEMBER_NOT_FOUND, INVALID_PASSWORD, INACTIVE_MEMBER 등)

  변경 사항
  - `MemberCommandService`: login() 메서드 추가
  - `MemberLoginRequest`: 로그인 요청 DTO 구현 (validation 포함)
  - `ErrorCode`: Auth 관련 에러 코드 7개 추가