### PR TITLE
[Feat] 오답노트 조회 필터 확장 및 재학습 세트 생성 API 구현

### DIFF
--- a/src/main/java/com/team/jpquiz/quiz/command/application/QuizCommandService.java
+++ b/src/main/java/com/team/jpquiz/quiz/command/application/QuizCommandService.java
@@ -226,4 +226,13 @@ public class QuizCommandService {
         }
         return null;
     }
+
+    private void updateWrongAnswerNote(Long userId, Long questionId, boolean correct) {
+        if (correct) {
+            wrongAnswerCommandService.deleteWrongAnswer(userId, questionId);
+            return;
+        }
+
+        wrongAnswerCommandService.saveWrongAnswer(userId, new WrongAnswerSaveRequest(questionId));
+    }
 }

--- a/src/main/java/com/team/jpquiz/quiz/command/application/WrongAnswerReviewCommandService.java
+++ b/src/main/java/com/team/jpquiz/quiz/command/application/WrongAnswerReviewCommandService.java
@@ -1,0 +1,87 @@
+package com.team.jpquiz.quiz.command.application;
+
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
+import com.team.jpquiz.quiz.command.infrastructure.QuizCommandMapper;
+import com.team.jpquiz.quiz.dto.response.QuizAttemptResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WrongAnswerReviewCommandService {
+
+    private static final int REVIEW_SET_SIZE = 10;
+
+    private final QuizCommandMapper quizCommandMapper;
+
+    public QuizAttemptResponse createReviewSet(Long memberId) {
+        validateMember(memberId);
+
+        int totalQuestions = quizCommandMapper.countAllQuestions();
+        if (totalQuestions < REVIEW_SET_SIZE) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        List<Long> selectedQuestionIds = new ArrayList<>(
+                quizCommandMapper.findRecentWrongQuestionIds(memberId, REVIEW_SET_SIZE)
+        );
+
+        int remainingCount = REVIEW_SET_SIZE - selectedQuestionIds.size();
+        if (remainingCount > 0) {
+            List<Long> randomQuestionIds =
+                    quizCommandMapper.findRandomQuestionIdsExcept(remainingCount, selectedQuestionIds);
+            if (randomQuestionIds.size() != remainingCount) {
+                throw new CustomException(ErrorCode.INTERNAL_ERROR);
+            }
+            selectedQuestionIds.addAll(randomQuestionIds);
+        }
+
+        return createAttempt(memberId, selectedQuestionIds);
+    }
+
+    private QuizAttemptResponse createAttempt(Long memberId, List<Long> questionIds) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("userId", memberId);
+        params.put("totalQuestions", questionIds.size());
+        quizCommandMapper.insertQuizAttempt(params);
+
+        Object generatedAttemptId = params.get("attemptId");
+        if (!(generatedAttemptId instanceof Number)) {
+            throw new CustomException(ErrorCode.INTERNAL_ERROR);
+        }
+        Long attemptId = ((Number) generatedAttemptId).longValue();
+
+        for (int i = 0; i < questionIds.size(); i++) {
+            Long questionId = questionIds.get(i);
+            String choiceOrder = quizCommandMapper.findChoiceOrderCsv(questionId);
+
+            int inserted = quizCommandMapper.insertQuizAttemptQuestion(
+                    attemptId,
+                    i + 1,
+                    questionId,
+                    choiceOrder
+            );
+            if (inserted != 1) {
+                throw new CustomException(ErrorCode.INTERNAL_ERROR);
+            }
+        }
+
+        return QuizAttemptResponse.builder()
+                .attemptId(attemptId)
+                .totalQuestions(questionIds.size())
+                .build();
+    }
+
+    private void validateMember(Long memberId) {
+        if (memberId == null || memberId <= 0) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/team/jpquiz/quiz/command/infrastructure/QuizCommandMapper.java
+++ b/src/main/java/com/team/jpquiz/quiz/command/infrastructure/QuizCommandMapper.java
@@ -13,6 +13,16 @@ public interface QuizCommandMapper {
 
     List<Long> findRandomQuestionIds(@Param("count") int count);
 
+    List<Long> findRecentWrongQuestionIds(
+            @Param("memberId") Long memberId,
+            @Param("limit") int limit
+    );
+
+    List<Long> findRandomQuestionIdsExcept(
+            @Param("count") int count,
+            @Param("excludeIds") List<Long> excludeIds
+    );
+
     String findChoiceOrderCsv(@Param("questionId") Long questionId);
 
     void insertQuizAttempt(Map<String, Object> params);

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/WrongAnswerResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/WrongAnswerResponse.java
@@ -16,6 +16,8 @@ import java.time.LocalDateTime;
 public class WrongAnswerResponse {
 
   private Long questionId;
+  private String questionText;
+  private String category;
   private int wrongCount;
   private LocalDateTime lastWrongAt;
 

--- a/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerCommandController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerCommandController.java
@@ -3,7 +3,9 @@ package com.team.jpquiz.quiz.presentation;
 import com.team.jpquiz.common.dto.ApiResponse;
 import com.team.jpquiz.common.util.SecurityUtil;
 import com.team.jpquiz.quiz.command.application.WrongAnswerCommandService;
+import com.team.jpquiz.quiz.command.application.WrongAnswerReviewCommandService;
 import com.team.jpquiz.quiz.dto.request.WrongAnswerSaveRequest;
+import com.team.jpquiz.quiz.dto.response.QuizAttemptResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class WrongAnswerCommandController {
 
   private final WrongAnswerCommandService wrongAnswerCommandService;
+  private final WrongAnswerReviewCommandService wrongAnswerReviewCommandService;
 
   // 오답 수동 저장 (테스트용)
   @PostMapping
@@ -32,5 +35,14 @@ public class WrongAnswerCommandController {
 
     wrongAnswerCommandService.deleteWrongAnswer(currentMemberId, questionId);
     return ApiResponse.ok();
+  }
+
+  // 오답노트 재학습 세트 생성 (10문제 고정, 부족분 랜덤 보충)
+  @PostMapping("/review-set")
+  public ApiResponse<QuizAttemptResponse> createReviewSet() {
+    Long currentMemberId = SecurityUtil.getCurrentMemberId();
+
+    QuizAttemptResponse response = wrongAnswerReviewCommandService.createReviewSet(currentMemberId);
+    return ApiResponse.ok(response);
   }
 }

--- a/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerQueryController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/WrongAnswerQueryController.java
@@ -28,10 +28,19 @@ public class WrongAnswerQueryController {
       @AuthenticationPrincipal UserPrincipal userPrincipal,
       @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "10") int size,
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) String category
   ) {
     PageResponse<WrongAnswerResponse> response =
-        wrongAnswerQueryService.getWrongAnswerList(userPrincipal.getUserId(), page, size, fromDate);
+        wrongAnswerQueryService.getWrongAnswerList(
+            userPrincipal.getUserId(),
+            page,
+            size,
+            fromDate,
+            keyword,
+            category
+        );
     return ApiResponse.ok(response);
   }
 }

--- a/src/main/java/com/team/jpquiz/quiz/query/application/WrongAnswerQueryService.java
+++ b/src/main/java/com/team/jpquiz/quiz/query/application/WrongAnswerQueryService.java
@@ -1,6 +1,8 @@
 package com.team.jpquiz.quiz.query.application;
 
 import com.team.jpquiz.common.dto.PageResponse;
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
 import com.team.jpquiz.quiz.dto.response.WrongAnswerResponse;
 import com.team.jpquiz.quiz.query.infrastructure.WrongAnswerMapper; // 패키지 경로 주의 (infrastructure 바로 아래인지, mapper 폴더 안인지)
 import java.time.LocalDate;
@@ -24,15 +26,27 @@ public class WrongAnswerQueryService {
       Long memberId,
       int page,
       int size,
-      LocalDate fromDate
+      LocalDate fromDate,
+      String keyword,
+      String category
   ) {
+    validateInput(memberId, page, size);
     int offset = (page - 1) * size; // 1-based page -> 0-based offset
     LocalDateTime fromDateTime = fromDate != null ? fromDate.atStartOfDay() : null;
 
     List<WrongAnswerResponse> content =
-        wrongAnswerMapper.findWrongAnswers(memberId, offset, size, fromDateTime);
-    long totalElements = wrongAnswerMapper.countWrongAnswers(memberId, fromDateTime);
+        wrongAnswerMapper.findWrongAnswers(memberId, offset, size, fromDateTime, keyword, category);
+    long totalElements = wrongAnswerMapper.countWrongAnswers(memberId, fromDateTime, keyword, category);
 
     return PageResponse.of(content, page, size, totalElements);
+  }
+
+  private void validateInput(Long memberId, int page, int size) {
+    if (memberId == null || memberId <= 0) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+    if (page < 1 || size < 1 || size > 100) {
+      throw new CustomException(ErrorCode.INVALID_REQUEST);
+    }
   }
 }

--- a/src/main/java/com/team/jpquiz/quiz/query/infrastructure/WrongAnswerMapper.java
+++ b/src/main/java/com/team/jpquiz/quiz/query/infrastructure/WrongAnswerMapper.java
@@ -16,12 +16,16 @@ public interface WrongAnswerMapper {
       @Param("memberId") Long memberId,
       @Param("offset") int offset,
       @Param("limit") int limit,
-      @Param("fromDateTime") LocalDateTime fromDateTime
+      @Param("fromDateTime") LocalDateTime fromDateTime,
+      @Param("keyword") String keyword,
+      @Param("category") String category
   );
 
   // 회원별 오답노트 전체 건수를 조회합니다.
   long countWrongAnswers(
       @Param("memberId") Long memberId,
-      @Param("fromDateTime") LocalDateTime fromDateTime
+      @Param("fromDateTime") LocalDateTime fromDateTime,
+      @Param("keyword") String keyword,
+      @Param("category") String category
   );
 }

--- a/src/main/resources/mappers/quiz/QuizCommandMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizCommandMapper.xml
@@ -19,6 +19,32 @@
         LIMIT #{count}
     </select>
 
+    <!-- 오답노트 최신순 문제 ID를 limit개 추출 -->
+    <select id="findRecentWrongQuestionIds" resultType="long">
+        SELECT wa.question_id
+        FROM wrong_answers wa
+        JOIN quiz_questions qq ON qq.question_id = wa.question_id
+        WHERE wa.member_id = #{memberId}
+        ORDER BY COALESCE(wa.last_wrong_at, wa.created_at) DESC
+        LIMIT #{limit}
+    </select>
+
+    <!-- 제외 목록을 뺀 랜덤 문제 ID 추출 -->
+    <select id="findRandomQuestionIdsExcept" resultType="long">
+        SELECT qq.question_id
+        FROM quiz_questions qq
+        <where>
+            <if test="excludeIds != null and excludeIds.size() > 0">
+                qq.question_id NOT IN
+                <foreach collection="excludeIds" item="id" open="(" separator="," close=")">
+                    #{id}
+                </foreach>
+            </if>
+        </where>
+        ORDER BY RAND()
+        LIMIT #{count}
+    </select>
+
     <!-- 문제별 보기 순서를 CSV로 고정 저장하기 위한 값 생성 -->
     <select id="findChoiceOrderCsv" resultType="string">
         SELECT GROUP_CONCAT(qc.choice_id ORDER BY RAND() SEPARATOR ',')

--- a/src/main/resources/mappers/quiz/WrongAnswerMapper.xml
+++ b/src/main/resources/mappers/quiz/WrongAnswerMapper.xml
@@ -7,12 +7,22 @@
     <select id="findWrongAnswers" resultType="com.team.jpquiz.quiz.dto.response.WrongAnswerResponse">
         SELECT
             wa.question_id AS questionId,
+            qq.question_text AS questionText,
+            qs.name AS category,
             wa.wrong_count AS wrongCount,
             wa.last_wrong_at AS lastWrongAt
         FROM wrong_answers wa
+        JOIN quiz_questions qq ON qq.question_id = wa.question_id
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
         WHERE wa.member_id = #{memberId}
         <if test="fromDateTime != null">
             AND COALESCE(wa.last_wrong_at, wa.created_at) &gt;= #{fromDateTime}
+        </if>
+        <if test="keyword != null and keyword != ''">
+            AND qq.question_text LIKE CONCAT('%', #{keyword}, '%')
+        </if>
+        <if test="category != null and category != ''">
+            AND qs.name = #{category}
         </if>
         ORDER BY COALESCE(wa.last_wrong_at, wa.created_at) DESC
             LIMIT #{limit} OFFSET #{offset}
@@ -21,10 +31,18 @@
     <!-- 전체 오답 개수 조회 -->
     <select id="countWrongAnswers" resultType="long">
         SELECT COUNT(*)
-        FROM wrong_answers
-        WHERE member_id = #{memberId}
+        FROM wrong_answers wa
+        JOIN quiz_questions qq ON qq.question_id = wa.question_id
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
+        WHERE wa.member_id = #{memberId}
         <if test="fromDateTime != null">
-            AND COALESCE(last_wrong_at, created_at) &gt;= #{fromDateTime}
+            AND COALESCE(wa.last_wrong_at, wa.created_at) &gt;= #{fromDateTime}
+        </if>
+        <if test="keyword != null and keyword != ''">
+            AND qq.question_text LIKE CONCAT('%', #{keyword}, '%')
+        </if>
+        <if test="category != null and category != ''">
+            AND qs.name = #{category}
         </if>
     </select>
 


### PR DESCRIPTION
## 작업 내용
  - 오답노트 기능을 실사용 기준으로 확장했습니다.
  - 오답 조회 API에 검색/필터 조건을 추가했습니다.
  - 오답노트 재학습 세트 생성 API를 추가했습니다.
  - 퀴즈 답안 제출 후 오답노트 자동 반영 로직을 보완했습니다.

  ## 상세 변경 사항
  - 오답 조회 필터 확장
    - API: `GET /api/quiz/wrong-answers`
    - Query Parameter(쿼리 파라미터): `page`, `size`, `fromDate`, `keyword`, `category`
    - `WrongAnswerResponse` 필드 확장: `questionText`, `category` 추가
    - MyBatis(마이바티스) 쿼리에서 `quiz_questions`, `quiz_scenes` 조인 및 조건 검색 반영

  - 오답노트 재학습 세트 생성 추가
    - API: `POST /api/quiz/wrong-answers/review-set`
    - 규칙:
      1. 오답노트 최신순 문제 우선 선별
      2. 부족한 개수는 랜덤 문제로 보충
      3. 총 10문제 고정 세트 생성
    - 결과: `QuizAttemptResponse` 반환

  - 퀴즈 제출 흐름 보완
    - `QuizCommandService`에 `updateWrongAnswerNote` 메서드 보완
    - 정답 시 오답노트 삭제, 오답 시 Upsert 저장 처리

  - Mapper 확장
    - `QuizCommandMapper` / `QuizCommandMapper.xml`
      - `findRecentWrongQuestionIds`
      - `findRandomQuestionIdsExcept`
    - `WrongAnswerMapper` / `WrongAnswerMapper.xml`
      - `keyword`, `category`, `fromDateTime` 기반 필터 조회/카운트

  ## 테스트 방법
  1. 로그인 후 Access Token(액세스 토큰) 발급
  2. 오답 조회 API 확인
     - 기본 조회: `GET /api/quiz/wrong-answers?page=1&size=10`
     - 날짜 필터: `GET /api/quiz/wrong-answers?page=1&size=10&fromDate=2026-02-01`
     - 키워드 검색: `GET /api/quiz/wrong-answers?page=1&size=10&keyword=...`
     - 카테고리 필터: `GET /api/quiz/wrong-answers?page=1&size=10&category=...`
     - 복합 조건: `fromDate + keyword + category` 조합 확인
  3. 재학습 세트 생성 확인
     - `POST /api/quiz/wrong-answers/review-set`
     - 응답의 `attemptId`, `totalQuestions=10` 확인
  4. 자동 반영 확인
     - `POST /api/quiz/attempts/{attemptId}/answers` 호출
     - 오답 제출 시 `wrong_answers` 저장/증가
     - 정답 제출 시 `wrong_answers` 삭제
  5. 빌드 확인
     - Java 17 환경에서 `./gradlew compileJava -q` 성공 확인