### PR TITLE
[Feat] 즐겨찾기 토글 API 추가 및 조회 경로 정합성 반영

### DIFF
--- a/src/main/java/com/team/jpquiz/quiz/command/application/FavoriteCommandService.java
+++ b/src/main/java/com/team/jpquiz/quiz/command/application/FavoriteCommandService.java
@@ -2,6 +2,7 @@ package com.team.jpquiz.quiz.command.application;
 
 import com.team.jpquiz.quiz.command.domain.Favorite;
 import com.team.jpquiz.quiz.command.domain.repository.FavoriteRepository;
+import com.team.jpquiz.quiz.dto.response.FavoriteToggleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,5 +32,29 @@ public class FavoriteCommandService {
   // 즐겨찾기 항목을 삭제합니다.
   public void deleteFavorite(Long memberId, Long questionId) {
     favoriteRepository.deleteByMemberIdAndQuestionId(memberId, questionId);
+  }
+
+  // 현재 상태를 반전해 즐겨찾기 토글을 처리합니다.
+  public FavoriteToggleResponse toggleFavorite(Long memberId, Long questionId) {
+    return favoriteRepository.findByMemberIdAndQuestionId(memberId, questionId)
+        .map(existing -> {
+          favoriteRepository.delete(existing);
+          return FavoriteToggleResponse.builder()
+              .questionId(questionId)
+              .favorited(false)
+              .build();
+        })
+        .orElseGet(() -> {
+          favoriteRepository.save(
+              Favorite.builder()
+                  .memberId(memberId)
+                  .questionId(questionId)
+                  .build()
+          );
+          return FavoriteToggleResponse.builder()
+              .questionId(questionId)
+              .favorited(true)
+              .build();
+        });
   }
 }

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/FavoriteToggleResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/FavoriteToggleResponse.java
@@ -1,0 +1,16 @@
+package com.team.jpquiz.quiz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteToggleResponse {
+
+    private Long questionId;
+    private boolean favorited;
+}

--- a/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteCommandController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteCommandController.java
@@ -1,7 +1,9 @@
 package com.team.jpquiz.quiz.presentation;
 
+import com.team.jpquiz.common.dto.ApiResponse;
 import com.team.jpquiz.global.security.UserPrincipal;
 import com.team.jpquiz.quiz.command.application.FavoriteCommandService;
+import com.team.jpquiz.quiz.dto.response.FavoriteToggleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,6 +35,16 @@ public class FavoriteCommandController {
   ) {
     favoriteCommandService.deleteFavorite(userPrincipal.getUserId(), questionId);
     return ResponseEntity.noContent().build();
+  }
+
+  // 문제의 즐겨찾기 상태를 토글합니다.
+  @PostMapping("/{questionId}/toggle")
+  public ApiResponse<FavoriteToggleResponse> toggleFavorite(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      @PathVariable Long questionId
+  ) {
+    FavoriteToggleResponse response = favoriteCommandService.toggleFavorite(userPrincipal.getUserId(), questionId);
+    return ApiResponse.ok(response);
   }
 
 }

--- a/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteQueryController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteQueryController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/quiz/favorites")
+@RequestMapping("/api/favorites")
 @RequiredArgsConstructor
 public class FavoriteQueryController {
 


### PR DESCRIPTION
 ## 작업 내용
  - 즐겨찾기 토글 API를 추가했습니다.
  - 즐겨찾기 조회 API 경로를 Command(명령) API와 동일한 규칙으로 정렬했습니다.

  ## 상세 변경 사항
  - 토글 응답 DTO(Response, 응답 객체) 추가
    - `FavoriteToggleResponse`
    - 필드: `questionId`, `favorited`
  - Service(서비스) 확장
    - `FavoriteCommandService#toggleFavorite(Long memberId, Long questionId)` 추가
    - 기존 즐겨찾기 존재 시 삭제(`favorited=false`), 없으면 저장(`favorited=true`)
  - Controller(컨트롤러) 확장
    - `POST /api/favorites/{questionId}/toggle` 추가
  - 조회 API 경로 정합성 맞춤
    - `FavoriteQueryController` 경로 변경
    - `/api/quiz/favorites` -> `/api/favorites`

  ## 테스트 방법
  1. 로그인 후 Access Token(액세스 토큰) 발급
  2. 토글 API 확인
     - `POST /api/favorites/{questionId}/toggle`
     - 최초 호출: `favorited=true`
     - 재호출: `favorited=false`
  3. 조회 API 확인
     - `GET /api/favorites?page=1&size=10`
     - `GET /api/favorites?page=1&size=10&category=...`
  4. 기존 등록/해제 API 회귀 확인
     - `POST /api/favorites/{questionId}`
     - `DELETE /api/favorites/{questionId}`
  5. 빌드 확인
     - Java 17 환경에서 `./gradlew compileJava -q` 성공