### PR TITLE
[Feat] 퀴즈 결과 조회 기능 구현

### DIFF
--- a/QuizHistory.md
+++ b/QuizHistory.md
@@ -224,6 +224,12 @@
       - 타인 attempt 결과 조회 시도
     - `404 ATTEMPT_NOT_FOUND`
       - attempt 없음
+- [DONE] 5-2. 결과 조회 DTO 구현
+  - `QuizResultResponse`
+    - 필드: `attemptId`, `totalQuestions`, `solvedCount`, `correctCount`, `accuracy`, `completedAt`
+  - 구현 의도:
+    - 결과 조회 API는 요약 통계 중심으로 반환
+    - 문항별 상세 결과는 필요 시 후속 DTO로 분리 확장
 
 ## DB 매핑 메모
 - [CONFIRMED] 1-2. MyBatis Mapper/쿼리 설계 (Attempt 기반 조회)

--- a/src/main/java/com/team/jpquiz/quiz/dto/response/QuizResultResponse.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/response/QuizResultResponse.java
@@ -1,0 +1,22 @@
+package com.team.jpquiz.quiz.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizResultResponse {
+
+    private Long attemptId;
+    private int totalQuestions;
+    private int solvedCount;
+    private int correctCount;
+    private int accuracy;
+    private LocalDateTime completedAt;
+}


### PR DESCRIPTION
  ## 작업 내용
  - 퀴즈 5단계(결과 조회) 기능을 구현했습니다.
  - attempt 기준 결과 요약 정보를 조회할 수 있도록 API/DTO/Mapper/Service/Controller를 연결했습니다.

  ## 상세 변경 사항
  - API
    - `GET /api/quiz/attempts/{attemptId}/result` 추가
  - DTO
    - `QuizResultResponse` 추가
    - 결과 응답 필드: `attemptId`, `totalQuestions`, `solvedCount`, `correctCount`, `accuracy`, `completedAt`
  - Mapper/SQL
    - 결과 조회용 attempt 메타/제출 집계/정답 집계 쿼리 추가
    - 완료 여부 조회 조건 반영
  - Service
    - 입력 검증(`attemptId`)
    - attempt 존재 검증
    - 소유권 검증(타인 attempt 차단)
    - 완료 여부 검증(완료 전 조회 차단)
    - 결과 집계 및 응답 조립
  - Controller
    - 결과 조회 엔드포인트 연결
    - `ApiResponse` 표준 응답 반환
  - 문서
    - `QuizHistory.md`에 5단계 진행 내역 반영

  ## 예외 처리 정책
  - `400 INVALID_REQUEST`
    - 잘못된 path 값
    - 완료 전 attempt 조회 요청
  - `401 UNAUTHORIZED`
    - 미인증 요청
  - `403 FORBIDDEN`
    - 타인 attempt 조회 요청
  - `404 ATTEMPT_NOT_FOUND`
    - 존재하지 않는 attempt

  ## 테스트 방법
  - Java 17 환경에서 컴파일 확인
    - `./gradlew compileJava`
  - 수동 API 확인
    - 정상(`200`): 본인 완료 attempt 결과 조회
    - 오류(`400`): 완료 전 attempt 조회
    - 오류(`401`): 미인증 요청
    - 오류(`403`): 타인 attempt 조회
    - 오류(`404`): 없는 attempt 조회

  ## 관련 이슈
  - QUIZ 5단계: 결과 조회
