### PR TITLE
[feat] [Feat] 문제 신고 기능 1차 구현 (게스트 신고 허용, 관리자 조회/처리 API 추가)

### DIFF
--- a/src/main/java/com/team/jpquiz/global/error/ErrorCode.java
+++ b/src/main/java/com/team/jpquiz/global/error/ErrorCode.java
@@ -26,7 +26,12 @@ public enum ErrorCode {
     ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "ALREADY_WITHDRAWN", "이미 탈퇴한 회원입니다."),
 
     // Quiz
-    GUEST_QUIZ_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "GUEST_QUIZ_LIMIT_EXCEEDED", "비회원은 퀴즈를 1개만 풀 수 있습니다. 로그인 후 이용해주세요.");
+    GUEST_QUIZ_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "GUEST_QUIZ_LIMIT_EXCEEDED", "비회원은 퀴즈를 1개만 풀 수 있습니다. 로그인 후 이용해주세요."),
+
+    // Problem Report
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_NOT_FOUND", "신고 내역을 찾을 수 없습니다."),
+    INVALID_REPORT_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_REPORT_STATUS_TRANSITION", "신고 상태 전이가 올바르지 않습니다."),
+    REPORT_TARGET_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_TARGET_QUESTION_NOT_FOUND", "신고 대상 문제를 찾을 수 없습니다.");
 
 
 

--- a/src/main/java/com/team/jpquiz/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/team/jpquiz/global/error/GlobalExceptionHandler.java
@@ -4,9 +4,11 @@ import com.team.jpquiz.common.dto.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -29,6 +31,21 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
     public ResponseEntity<ErrorResponse> handleValidationException(
+            Exception ex,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+        ErrorResponse body = ErrorResponse.of(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                errorCode.getStatus().value(),
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class, HttpMessageNotReadableException.class})
+    public ResponseEntity<ErrorResponse> handleParsingException(
             Exception ex,
             HttpServletRequest request
     ) {

--- a/src/main/java/com/team/jpquiz/global/security/SecurityConfig.java
+++ b/src/main/java/com/team/jpquiz/global/security/SecurityConfig.java
@@ -96,6 +96,8 @@ public class SecurityConfig {
 
                         // 인증 API - 공개
                         .requestMatchers("/api/auth/**").permitAll()
+                        // 신고 등록 API - 게스트 포함 공개
+                        .requestMatchers(HttpMethod.POST, "/api/reports").permitAll()
 
                         // 퀴즈 API - 비회원도 접근 가능 (횟수 제한은 서비스 레이어에서 처리)
                         .requestMatchers(HttpMethod.GET, "/api/quizzes/**").permitAll()

--- a/src/main/java/com/team/jpquiz/report/command/application/ProblemReportCommandService.java
+++ b/src/main/java/com/team/jpquiz/report/command/application/ProblemReportCommandService.java
@@ -1,0 +1,67 @@
+package com.team.jpquiz.report.command.application;
+
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
+import com.team.jpquiz.report.command.domain.ProblemReport;
+import com.team.jpquiz.report.command.domain.ReportStatus;
+import com.team.jpquiz.report.command.infrastructure.ProblemReportRepository;
+import com.team.jpquiz.report.command.infrastructure.ProblemReportValidationMapper;
+import com.team.jpquiz.report.dto.request.ProblemReportCreateRequest;
+import com.team.jpquiz.report.dto.request.ProblemReportStatusUpdateRequest;
+import com.team.jpquiz.report.dto.response.ProblemReportCreateResponse;
+import com.team.jpquiz.report.dto.response.ProblemReportStatusUpdateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProblemReportCommandService {
+
+    private final ProblemReportRepository problemReportRepository;
+    private final ProblemReportValidationMapper problemReportValidationMapper;
+
+    public ProblemReportCreateResponse createReport(Long reporterId, ProblemReportCreateRequest request) {
+        validateReporterId(reporterId);
+        validateQuestionId(request.getQuestionId());
+
+        ProblemReport problemReport = ProblemReport.builder()
+                .questionId(request.getQuestionId())
+                .reporterId(reporterId)
+                .reportType(request.getReportType())
+                .content(request.getContent())
+                .build();
+
+        ProblemReport saved = problemReportRepository.save(problemReport);
+        return ProblemReportCreateResponse.from(saved);
+    }
+
+    public ProblemReportStatusUpdateResponse updateReportStatus(
+            Long reportId,
+            ProblemReportStatusUpdateRequest request
+    ) {
+        ProblemReport problemReport = problemReportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REPORT_NOT_FOUND));
+
+        ReportStatus currentStatus = problemReport.getStatus();
+        if (!currentStatus.canTransitionTo(request.getStatus())) {
+            throw new CustomException(ErrorCode.INVALID_REPORT_STATUS_TRANSITION);
+        }
+
+        problemReport.updateStatus(request.getStatus(), request.getAction());
+        return ProblemReportStatusUpdateResponse.from(problemReport);
+    }
+
+    private void validateReporterId(Long reporterId) {
+        if (reporterId != null && reporterId <= 0) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private void validateQuestionId(Long questionId) {
+        if (problemReportValidationMapper.countQuestionById(questionId) == 0) {
+            throw new CustomException(ErrorCode.REPORT_TARGET_QUESTION_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/command/domain/ProblemReport.java
+++ b/src/main/java/com/team/jpquiz/report/command/domain/ProblemReport.java
@@ -1,0 +1,90 @@
+package com.team.jpquiz.report.command.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "problem_reports")
+public class ProblemReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @Column(name = "question_id", nullable = false)
+    private Long questionId;
+
+    @Column(name = "reporter_id")
+    private Long reporterId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_type", nullable = false, length = 30)
+    private ReportType reportType;
+
+    @Column(name = "content", nullable = false, length = 1000)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private ReportStatus status;
+
+    @Column(name = "action", length = 500)
+    private String action;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public ProblemReport(
+            Long questionId,
+            Long reporterId,
+            ReportType reportType,
+            String content
+    ) {
+        this.questionId = questionId;
+        this.reporterId = reporterId;
+        this.reportType = reportType;
+        this.content = content;
+        this.status = ReportStatus.PENDING;
+    }
+
+    public void updateStatus(ReportStatus status, String action) {
+        this.status = status;
+        this.action = action;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.status == null) {
+            this.status = ReportStatus.PENDING;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/command/domain/ReportStatus.java
+++ b/src/main/java/com/team/jpquiz/report/command/domain/ReportStatus.java
@@ -1,0 +1,26 @@
+package com.team.jpquiz.report.command.domain;
+
+public enum ReportStatus {
+    PENDING,
+    IN_REVIEW,
+    RESOLVED,
+    REJECTED;
+
+    public boolean canTransitionTo(ReportStatus nextStatus) {
+        if (nextStatus == null) {
+            return false;
+        }
+
+        return switch (this) {
+            case PENDING -> nextStatus == PENDING
+                    || nextStatus == IN_REVIEW
+                    || nextStatus == RESOLVED
+                    || nextStatus == REJECTED;
+            case IN_REVIEW -> nextStatus == IN_REVIEW
+                    || nextStatus == RESOLVED
+                    || nextStatus == REJECTED;
+            case RESOLVED -> nextStatus == RESOLVED;
+            case REJECTED -> nextStatus == REJECTED;
+        };
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/command/domain/ReportType.java
+++ b/src/main/java/com/team/jpquiz/report/command/domain/ReportType.java
@@ -1,0 +1,7 @@
+package com.team.jpquiz.report.command.domain;
+
+public enum ReportType {
+    TYPO,
+    WRONG_ANSWER,
+    ETC
+}

--- a/src/main/java/com/team/jpquiz/report/command/infrastructure/ProblemReportRepository.java
+++ b/src/main/java/com/team/jpquiz/report/command/infrastructure/ProblemReportRepository.java
@@ -1,0 +1,7 @@
+package com.team.jpquiz.report.command.infrastructure;
+
+import com.team.jpquiz.report.command.domain.ProblemReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemReportRepository extends JpaRepository<ProblemReport, Long> {
+}

--- a/src/main/java/com/team/jpquiz/report/command/infrastructure/ProblemReportValidationMapper.java
+++ b/src/main/java/com/team/jpquiz/report/command/infrastructure/ProblemReportValidationMapper.java
@@ -1,0 +1,10 @@
+package com.team.jpquiz.report.command.infrastructure;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ProblemReportValidationMapper {
+
+    int countQuestionById(@Param("questionId") Long questionId);
+}

--- a/src/main/java/com/team/jpquiz/report/dto/request/ProblemReportCreateRequest.java
+++ b/src/main/java/com/team/jpquiz/report/dto/request/ProblemReportCreateRequest.java
@@ -1,0 +1,25 @@
+package com.team.jpquiz.report.dto.request;
+
+import com.team.jpquiz.report.command.domain.ReportType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProblemReportCreateRequest {
+
+    @NotNull
+    @Positive
+    private Long questionId;
+
+    @NotNull
+    private ReportType reportType;
+
+    @NotBlank
+    @Size(max = 1000)
+    private String content;
+}

--- a/src/main/java/com/team/jpquiz/report/dto/request/ProblemReportStatusUpdateRequest.java
+++ b/src/main/java/com/team/jpquiz/report/dto/request/ProblemReportStatusUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.team.jpquiz.report.dto.request;
+
+import com.team.jpquiz.report.command.domain.ReportStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProblemReportStatusUpdateRequest {
+
+    @NotNull
+    private ReportStatus status;
+
+    @NotBlank
+    @Size(max = 500)
+    private String action;
+}

--- a/src/main/java/com/team/jpquiz/report/dto/response/ProblemReportAdminResponse.java
+++ b/src/main/java/com/team/jpquiz/report/dto/response/ProblemReportAdminResponse.java
@@ -1,0 +1,23 @@
+package com.team.jpquiz.report.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemReportAdminResponse {
+    private Long reportId;
+    private Long questionId;
+    private Long reporterId;
+    private String reportType;
+    private String content;
+    private String status;
+    private String action;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/jpquiz/report/dto/response/ProblemReportCreateResponse.java
+++ b/src/main/java/com/team/jpquiz/report/dto/response/ProblemReportCreateResponse.java
@@ -1,0 +1,27 @@
+package com.team.jpquiz.report.dto.response;
+
+import com.team.jpquiz.report.command.domain.ProblemReport;
+import com.team.jpquiz.report.command.domain.ReportStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemReportCreateResponse {
+    private Long reportId;
+    private ReportStatus status;
+    private LocalDateTime createdAt;
+
+    public static ProblemReportCreateResponse from(ProblemReport problemReport) {
+        return ProblemReportCreateResponse.builder()
+                .reportId(problemReport.getReportId())
+                .status(problemReport.getStatus())
+                .createdAt(problemReport.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/dto/response/ProblemReportStatusUpdateResponse.java
+++ b/src/main/java/com/team/jpquiz/report/dto/response/ProblemReportStatusUpdateResponse.java
@@ -1,0 +1,29 @@
+package com.team.jpquiz.report.dto.response;
+
+import com.team.jpquiz.report.command.domain.ProblemReport;
+import com.team.jpquiz.report.command.domain.ReportStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemReportStatusUpdateResponse {
+    private Long reportId;
+    private ReportStatus status;
+    private String action;
+    private LocalDateTime updatedAt;
+
+    public static ProblemReportStatusUpdateResponse from(ProblemReport problemReport) {
+        return ProblemReportStatusUpdateResponse.builder()
+                .reportId(problemReport.getReportId())
+                .status(problemReport.getStatus())
+                .action(problemReport.getAction())
+                .updatedAt(problemReport.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/presentation/AdminProblemReportController.java
+++ b/src/main/java/com/team/jpquiz/report/presentation/AdminProblemReportController.java
@@ -1,0 +1,50 @@
+package com.team.jpquiz.report.presentation;
+
+import com.team.jpquiz.common.dto.ApiResponse;
+import com.team.jpquiz.common.dto.PageResponse;
+import com.team.jpquiz.report.command.application.ProblemReportCommandService;
+import com.team.jpquiz.report.dto.request.ProblemReportStatusUpdateRequest;
+import com.team.jpquiz.report.dto.response.ProblemReportAdminResponse;
+import com.team.jpquiz.report.dto.response.ProblemReportStatusUpdateResponse;
+import com.team.jpquiz.report.query.application.ProblemReportQueryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/reports")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminProblemReportController {
+
+    private final ProblemReportQueryService problemReportQueryService;
+    private final ProblemReportCommandService problemReportCommandService;
+
+    @GetMapping
+    public ApiResponse<PageResponse<ProblemReportAdminResponse>> getReportList(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String status
+    ) {
+        PageResponse<ProblemReportAdminResponse> response =
+                problemReportQueryService.getReportList(page, size, status);
+        return ApiResponse.ok(response);
+    }
+
+    @PatchMapping("/{reportId}")
+    public ApiResponse<ProblemReportStatusUpdateResponse> updateReportStatus(
+            @PathVariable Long reportId,
+            @Valid @RequestBody ProblemReportStatusUpdateRequest request
+    ) {
+        ProblemReportStatusUpdateResponse response =
+                problemReportCommandService.updateReportStatus(reportId, request);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/presentation/ProblemReportController.java
+++ b/src/main/java/com/team/jpquiz/report/presentation/ProblemReportController.java
@@ -1,0 +1,32 @@
+package com.team.jpquiz.report.presentation;
+
+import com.team.jpquiz.common.dto.ApiResponse;
+import com.team.jpquiz.global.security.UserPrincipal;
+import com.team.jpquiz.report.command.application.ProblemReportCommandService;
+import com.team.jpquiz.report.dto.request.ProblemReportCreateRequest;
+import com.team.jpquiz.report.dto.response.ProblemReportCreateResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ProblemReportController {
+
+    private final ProblemReportCommandService problemReportCommandService;
+
+    @PostMapping
+    public ApiResponse<ProblemReportCreateResponse> createReport(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody ProblemReportCreateRequest request
+    ) {
+        Long reporterId = userPrincipal != null ? userPrincipal.getUserId() : null;
+        ProblemReportCreateResponse response = problemReportCommandService.createReport(reporterId, request);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/query/application/ProblemReportQueryService.java
+++ b/src/main/java/com/team/jpquiz/report/query/application/ProblemReportQueryService.java
@@ -1,0 +1,55 @@
+package com.team.jpquiz.report.query.application;
+
+import com.team.jpquiz.common.dto.PageResponse;
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
+import com.team.jpquiz.report.command.domain.ReportStatus;
+import com.team.jpquiz.report.dto.response.ProblemReportAdminResponse;
+import com.team.jpquiz.report.query.infrastructure.ProblemReportMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemReportQueryService {
+
+    private final ProblemReportMapper problemReportMapper;
+
+    public PageResponse<ProblemReportAdminResponse> getReportList(
+            int page,
+            int size,
+            String status
+    ) {
+        validatePaging(page, size);
+
+        int offset = (page - 1) * size;
+        String statusName = normalizeStatus(status);
+
+        List<ProblemReportAdminResponse> content =
+                problemReportMapper.findReports(statusName, offset, size);
+        long totalElements = problemReportMapper.countReports(statusName);
+
+        return PageResponse.of(content, page, size, totalElements);
+    }
+
+    private void validatePaging(int page, int size) {
+        if (page < 1 || size < 1 || size > 100) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private String normalizeStatus(String status) {
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+
+        try {
+            return ReportStatus.valueOf(status.trim().toUpperCase()).name();
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/team/jpquiz/report/query/infrastructure/ProblemReportMapper.java
+++ b/src/main/java/com/team/jpquiz/report/query/infrastructure/ProblemReportMapper.java
@@ -1,0 +1,18 @@
+package com.team.jpquiz.report.query.infrastructure;
+
+import com.team.jpquiz.report.dto.response.ProblemReportAdminResponse;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ProblemReportMapper {
+
+    List<ProblemReportAdminResponse> findReports(
+            @Param("status") String status,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    long countReports(@Param("status") String status);
+}

--- a/src/main/resources/mappers/report/ProblemReportMapper.xml
+++ b/src/main/resources/mappers/report/ProblemReportMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.jpquiz.report.query.infrastructure.ProblemReportMapper">
+
+    <select id="findReports" resultType="com.team.jpquiz.report.dto.response.ProblemReportAdminResponse">
+        SELECT
+            pr.report_id AS reportId,
+            pr.question_id AS questionId,
+            pr.reporter_id AS reporterId,
+            pr.report_type AS reportType,
+            pr.content AS content,
+            pr.status AS status,
+            pr.action AS action,
+            pr.created_at AS createdAt,
+            pr.updated_at AS updatedAt
+        FROM problem_reports pr
+        <where>
+            <if test="status != null and status != ''">
+                pr.status = #{status}
+            </if>
+        </where>
+        ORDER BY pr.created_at DESC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countReports" resultType="long">
+        SELECT COUNT(*)
+        FROM problem_reports pr
+        <where>
+            <if test="status != null and status != ''">
+                pr.status = #{status}
+            </if>
+        </where>
+    </select>
+
+</mapper>

--- a/src/main/resources/mappers/report/ProblemReportValidationMapper.xml
+++ b/src/main/resources/mappers/report/ProblemReportValidationMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.jpquiz.report.command.infrastructure.ProblemReportValidationMapper">
+
+    <select id="countQuestionById" resultType="int">
+        SELECT COUNT(*)
+        FROM quiz_questions
+        WHERE question_id = #{questionId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 작업 내용
  - 문제 신고(Problem Report, 문제 신고) 기능 1차 구현
  - 게스트(Guest, 비회원) 신고 등록 허용
  - 관리자(Admin, 관리자) 신고 목록 조회/상태 처리 기능 추가

  ## 상세 변경 사항
  - 신고 도메인 추가
    - `ProblemReport` Entity(엔티티), `ReportStatus`/`ReportType` Enum(열거형), Repository(리포지토리), Service(서비스), Controller(컨
  트롤러)
  - API(Application Programming Interface, 응용 프로그램 인터페이스) 추가
    - `POST /api/reports` : 신고 등록 (게스트/회원 모두 가능)
    - `GET /api/admin/reports` : 관리자 신고 목록 조회 (상태 필터 + 페이징)
    - `PATCH /api/admin/reports/{reportId}` : 관리자 신고 상태 변경 + action(처리 메모) 저장
  - 보안(Security, 보안) 정책 반영
    - `POST /api/reports` 공개 허용(`permitAll`)
    - 관리자 API는 `@PreAuthorize("hasRole('ADMIN')")` 적용
  - 상태 전이 규칙 반영
    - `PENDING -> IN_REVIEW/RESOLVED/REJECTED`
    - `IN_REVIEW -> RESOLVED/REJECTED`
    - `RESOLVED`, `REJECTED`는 동일 상태만 허용
  - 유효성 검증 강화
    - 신고 대상 `questionId` 존재 여부 검증(MyBatis 쿼리)
  - 예외 처리 추가
    - `REPORT_NOT_FOUND`
    - `INVALID_REPORT_STATUS_TRANSITION`
    - `REPORT_TARGET_QUESTION_NOT_FOUND`
    - Enum 파싱/JSON 파싱 오류를 `INVALID_REQUEST`로 처리

  ## 테스트 방법
  1. 게스트 신고 등록
     - `POST /api/reports`
     - Body 예시:
       ```json
       {
         "questionId": 1,
         "reportType": "TYPO",
         "content": "보기 2번 오타가 있습니다."
       }
       ```
  2. 관리자 신고 목록 조회
     - `GET /api/admin/reports?page=1&size=10&status=PENDING`
     - 관리자 토큰으로 호출
  3. 관리자 신고 상태 변경
     - `PATCH /api/admin/reports/{reportId}`
     - Body 예시:
       ```json
       {
         "status": "IN_REVIEW",
         "action": "문항 검토 시작"
       }
       ```
  4. 권한 검증
     - 비관리자 계정으로 `/api/admin/reports/**` 접근 시 403 확인
  5. 예외 검증
     - 존재하지 않는 questionId로 신고 시 404(`REPORT_TARGET_QUESTION_NOT_FOUND`) 확인

  ## 관련 이슈
  - Closes #<이슈번호>

  ## 체크리스트
  - [x] 핵심 API 구현 완료
  - [x] 권한(401/403) 정책 반영
  - [x] 상태 전이/유효성 검증 반영
  - [ ] 단위 테스트(Unit Test, 단위 테스트) 작성
  - [ ] 통합 테스트(Integration Test, 통합 테스트) 작성
  - [ ] 로컬 컴파일 검증 (`Java 17` 툴체인 환경에서 필요)

  ## 참고
  - DB 스키마에서 `problem_reports.reporter_id`는 게스트 허용을 위해 `NULL` 가능해야 합니다.