### PR TITLE
[Feat] 통계 API 1차 구현 (개인 통계/관리자 개요)

### DIFF
--- a/src/main/java/com/team/jpquiz/stats/dto/response/StatsResponse.java
+++ b/src/main/java/com/team/jpquiz/stats/dto/response/StatsResponse.java
@@ -1,4 +1,41 @@
 package com.team.jpquiz.stats.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class StatsResponse {
+
+    private StatsResponse() {
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyStats {
+        private Long memberId;
+        private int totalAttempts;
+        private int completedAttempts;
+        private int totalAnswers;
+        private int correctAnswers;
+        private int recent7dAnswers;
+        private double completionRate;
+        private double accuracyRate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AdminOverview {
+        private int totalAttempts;
+        private int completedAttempts;
+        private int totalAnswers;
+        private int correctAnswers;
+        private int activeUsers7d;
+        private double completionRate;
+        private double accuracyRate;
+    }
 }

--- a/src/main/java/com/team/jpquiz/stats/presentation/StatsController.java
+++ b/src/main/java/com/team/jpquiz/stats/presentation/StatsController.java
@@ -1,4 +1,33 @@
 package com.team.jpquiz.stats.presentation;
 
+import com.team.jpquiz.common.dto.ApiResponse;
+import com.team.jpquiz.common.util.SecurityUtil;
+import com.team.jpquiz.stats.dto.response.StatsResponse;
+import com.team.jpquiz.stats.query.application.StatsQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class StatsController {
+
+    private final StatsQueryService statsQueryService;
+
+    @GetMapping("/stats/me")
+    public ApiResponse<StatsResponse.MyStats> getMyStats() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        StatsResponse.MyStats response = statsQueryService.getMyStats(memberId);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/admin/stats/overview")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<StatsResponse.AdminOverview> getAdminOverview() {
+        StatsResponse.AdminOverview response = statsQueryService.getAdminOverview();
+        return ApiResponse.ok(response);
+    }
 }

--- a/src/main/java/com/team/jpquiz/stats/query/application/StatsQueryService.java
+++ b/src/main/java/com/team/jpquiz/stats/query/application/StatsQueryService.java
@@ -1,4 +1,77 @@
 package com.team.jpquiz.stats.query.application;
 
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
+import com.team.jpquiz.stats.dto.response.StatsResponse;
+import com.team.jpquiz.stats.query.infrastructure.StatsMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StatsQueryService {
+
+    private final StatsMapper statsMapper;
+
+    public StatsResponse.MyStats getMyStats(Long memberId) {
+        validateMemberId(memberId);
+
+        StatsResponse.MyStats raw = statsMapper.findMyStats(memberId);
+
+        int totalAttempts = valueOrZero(raw != null ? raw.getTotalAttempts() : null);
+        int completedAttempts = valueOrZero(raw != null ? raw.getCompletedAttempts() : null);
+        int totalAnswers = valueOrZero(raw != null ? raw.getTotalAnswers() : null);
+        int correctAnswers = valueOrZero(raw != null ? raw.getCorrectAnswers() : null);
+        int recent7dAnswers = valueOrZero(raw != null ? raw.getRecent7dAnswers() : null);
+
+        return StatsResponse.MyStats.builder()
+                .memberId(memberId)
+                .totalAttempts(totalAttempts)
+                .completedAttempts(completedAttempts)
+                .totalAnswers(totalAnswers)
+                .correctAnswers(correctAnswers)
+                .recent7dAnswers(recent7dAnswers)
+                .completionRate(calculateRate(completedAttempts, totalAttempts))
+                .accuracyRate(calculateRate(correctAnswers, totalAnswers))
+                .build();
+    }
+
+    public StatsResponse.AdminOverview getAdminOverview() {
+        StatsResponse.AdminOverview raw = statsMapper.findAdminOverview();
+
+        int totalAttempts = valueOrZero(raw != null ? raw.getTotalAttempts() : null);
+        int completedAttempts = valueOrZero(raw != null ? raw.getCompletedAttempts() : null);
+        int totalAnswers = valueOrZero(raw != null ? raw.getTotalAnswers() : null);
+        int correctAnswers = valueOrZero(raw != null ? raw.getCorrectAnswers() : null);
+        int activeUsers7d = valueOrZero(raw != null ? raw.getActiveUsers7d() : null);
+
+        return StatsResponse.AdminOverview.builder()
+                .totalAttempts(totalAttempts)
+                .completedAttempts(completedAttempts)
+                .totalAnswers(totalAnswers)
+                .correctAnswers(correctAnswers)
+                .activeUsers7d(activeUsers7d)
+                .completionRate(calculateRate(completedAttempts, totalAttempts))
+                .accuracyRate(calculateRate(correctAnswers, totalAnswers))
+                .build();
+    }
+
+    private void validateMemberId(Long memberId) {
+        if (memberId == null || memberId <= 0) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private int valueOrZero(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private double calculateRate(int numerator, int denominator) {
+        if (denominator <= 0) {
+            return 0.0;
+        }
+        return Math.round((numerator * 10000.0) / denominator) / 100.0;
+    }
 }

--- a/src/main/java/com/team/jpquiz/stats/query/infrastructure/StatsMapper.java
+++ b/src/main/java/com/team/jpquiz/stats/query/infrastructure/StatsMapper.java
@@ -1,8 +1,13 @@
 package com.team.jpquiz.stats.query.infrastructure;
 
+import com.team.jpquiz.stats.dto.response.StatsResponse;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface StatsMapper {
 
+    StatsResponse.MyStats findMyStats(@Param("memberId") Long memberId);
+
+    StatsResponse.AdminOverview findAdminOverview();
 }

--- a/src/main/resources/mappers/stats/StatsMapper.xml
+++ b/src/main/resources/mappers/stats/StatsMapper.xml
@@ -3,4 +3,47 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.team.jpquiz.stats.query.infrastructure.StatsMapper">
+
+    <select id="findMyStats" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$MyStats">
+        SELECT
+            #{memberId} AS memberId,
+            (SELECT COUNT(*)
+             FROM quiz_attempts qa
+             WHERE qa.user_id = #{memberId}) AS totalAttempts,
+            (SELECT COUNT(*)
+             FROM quiz_attempts qa
+             WHERE qa.user_id = #{memberId}
+               AND qa.completed_at IS NOT NULL) AS completedAttempts,
+            (SELECT COUNT(*)
+             FROM quiz_attempt_answers qaa
+             JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+             WHERE qa.user_id = #{memberId}) AS totalAnswers,
+            (SELECT COUNT(*)
+             FROM quiz_attempt_answers qaa
+             JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+             WHERE qa.user_id = #{memberId}
+               AND qaa.is_correct = 1) AS correctAnswers,
+            (SELECT COUNT(*)
+             FROM quiz_attempt_answers qaa
+             JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+             WHERE qa.user_id = #{memberId}
+               AND qaa.answered_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)) AS recent7dAnswers
+    </select>
+
+    <select id="findAdminOverview" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$AdminOverview">
+        SELECT
+            (SELECT COUNT(*)
+             FROM quiz_attempts) AS totalAttempts,
+            (SELECT COUNT(*)
+             FROM quiz_attempts
+             WHERE completed_at IS NOT NULL) AS completedAttempts,
+            (SELECT COUNT(*)
+             FROM quiz_attempt_answers) AS totalAnswers,
+            (SELECT COUNT(*)
+             FROM quiz_attempt_answers
+             WHERE is_correct = 1) AS correctAnswers,
+            (SELECT COUNT(DISTINCT user_id)
+             FROM quiz_attempts
+             WHERE started_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)) AS activeUsers7d
+    </select>
 </mapper>


### PR DESCRIPTION
 ## 작업 내용
  - 통계(Statistics, 통계) 기능 1차 구현
  - 개인 통계 API `GET /api/stats/me` 추가
  - 관리자 개요 통계 API `GET /api/admin/stats/overview` 추가

  ## 상세 변경 사항
  - `StatsController` 구현
    - 개인 통계 조회 엔드포인트 추가
    - 관리자 개요 통계 조회 엔드포인트 추가 (`@PreAuthorize("hasRole('ADMIN')")`)
  - `StatsQueryService` 구현
    - 개인/관리자 통계 집계 결과 반환
    - 완료율(Completion Rate, 완료율), 정답률(Accuracy Rate, 정답률) 계산 로직 공통화
  - `StatsMapper` + `StatsMapper.xml` 구현 (MyBatis, 마이바티스)
    - 개인 통계 집계 쿼리
    - 관리자 개요 통계 집계 쿼리
  - `StatsResponse` DTO(데이터 전송 객체) 구현
    - `MyStats`, `AdminOverview` 내부 응답 타입 추가

  ## 테스트 방법
  1. 개인 통계 조회
     - `GET /api/stats/me`
     - 인증 토큰 포함 호출
     - 응답에 `totalAttempts`, `completedAttempts`, `accuracyRate` 등 필드 확인
  2. 관리자 개요 통계 조회
     - `GET /api/admin/stats/overview`
     - 관리자 토큰으로 호출
     - 응답에 `activeUsers7d`, `completionRate` 필드 확인
  3. 권한 검증
     - 일반 사용자 토큰으로 `/api/admin/stats/overview` 호출 시 403 확인
  4. 예외/빈 데이터 검증
     - 통계 데이터가 없는 환경에서도 0 기반 응답이 정상 반환되는지 확인

  ## 체크리스트
  - [x] 통계 API 2종 구현 완료
  - [x] 관리자 권한 제어 반영
  - [x] MyBatis 집계 쿼리 반영
  - [ ] 단위 테스트(Unit Test, 단위 테스트) 작성
  - [ ] 통합 테스트(Integration Test, 통합 테스트) 작성
  - [ ] Java 17(자바 17) 툴체인 환경에서 컴파일 검증