### PR TITLE
[Fix] 시작 API 문제 수 선택 제거 및 10문항 고정 적용

### DIFF
--- a/src/main/java/com/team/jpquiz/quiz/command/application/QuizCommandService.java
+++ b/src/main/java/com/team/jpquiz/quiz/command/application/QuizCommandService.java
@@ -25,13 +25,13 @@ import java.util.Map;
 @Transactional
 public class QuizCommandService {
 
+    private static final int FIXED_QUIZ_QUESTION_COUNT = 10;
+
     private final QuizCommandMapper quizCommandMapper;
     private final WrongAnswerCommandService wrongAnswerCommandService;
 
     public QuizAttemptResponse startQuiz(Long userId, StartQuizRequest request) {
-        validateInput(request);
-
-        int count = request.getCount();
+        int count = FIXED_QUIZ_QUESTION_COUNT;
         int totalQuestions = quizCommandMapper.countAllQuestions();
         if (totalQuestions < count) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
@@ -210,12 +210,6 @@ public class QuizCommandService {
                 .accuracy(accuracy)
                 .completedAt(completedAt)
                 .build();
-    }
-
-    private void validateInput(StartQuizRequest request) {
-        if (request == null || request.getCount() == null || request.getCount() < 1 || request.getCount() > 10) {
-            throw new CustomException(ErrorCode.INVALID_REQUEST);
-        }
     }
 
     private void validateSubmitInput(Long userId, Long attemptId, QuizSubmitRequest request) {

--- a/src/main/java/com/team/jpquiz/quiz/dto/request/StartQuizRequest.java
+++ b/src/main/java/com/team/jpquiz/quiz/dto/request/StartQuizRequest.java
@@ -1,16 +1,9 @@
 package com.team.jpquiz.quiz.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class StartQuizRequest {
-    @NotNull(message = "문제 수는 필수입니다.")
-    @Min(value = 1, message = "문제 수는 1 이상이어야 합니다.")
-    @Max(value = 10, message = "문제 수는 10 이하여야 합니다.")
-    private Integer count;
 }

--- a/src/main/java/com/team/jpquiz/quiz/presentation/QuizController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/QuizController.java
@@ -30,7 +30,7 @@ public class QuizController {
 
     @PostMapping("/attempts/start")
     public ApiResponse<QuizAttemptResponse> startQuiz(
-            @Valid @RequestBody StartQuizRequest request
+            @RequestBody(required = false) StartQuizRequest request
     ) {
         Long userId = SecurityUtil.getCurrentMemberIdOrNull();
         QuizAttemptResponse response = quizCommandService.startQuiz(userId, request);


### PR DESCRIPTION
PR 내용:

## 변경 배경

- 팀 정책(문제 10개 고정)에 맞춰 시작 API의 문제 수 선택 로직을 제거했습니다.
- 클라이언트/서버 모두에서 개수 선택으로 인한 불필요한 분기와 검증을 줄이기 위한 변경입니다.

## 작업 내용

- QuizCommandService
    - 시작 시 문제 수를 상수 10으로 고정
    - 요청 기반 count 검증 로직 제거
- StartQuizRequest
    - count 필드 및 @NotNull/@Min/@Max 제거
    - 시작 요청 DTO를 빈 바디 허용 형태로 정리
- QuizController
    - POST /api/quiz/attempts/start 요청 바디를 @RequestBody(required = false)로 변경

## 기대 효과

- 시작 API 동작 단순화
- 프론트/백엔드 정책 일치(항상 10문항)
- QA 범위 축소로 검증 안정성 향상

## 검증

- ./gradlew compileJava 통과
