### PR TITLE
[Bug] 즐겨찾기 조회 500 수정 및 오답노트/즐겨찾기 목록 UX 안정화

### DIFF
--- a/frontend/src/api/favoriteApi.js
+++ b/frontend/src/api/favoriteApi.js
@@ -1,7 +1,7 @@
 import { http, unwrap } from "./http";
 
 export async function getFavorites(page = 1, size = 10, category = null) {
-  const response = await http.get("/api/quiz/favorites", {
+  const response = await http.get("/api/favorites", {
     params: { page, size, category: category || undefined }
   });
   return unwrap(response);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -205,3 +205,27 @@ button {
   display: grid;
   gap: 6px;
 }
+
+.list-view {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.list-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.list-item p {
+  margin: 4px 0;
+}
+
+.pager {
+  align-items: center;
+  margin-top: 12px;
+}

--- a/frontend/src/views/FavoriteListView.vue
+++ b/frontend/src/views/FavoriteListView.vue
@@ -1,13 +1,36 @@
 <template>
   <section class="card">
     <h2>즐겨찾기</h2>
-    <p v-if="loading" class="muted">즐겨찾기를 불러오는 중입니다...</p>
-    <p v-else-if="errorMessage" class="error">{{ errorMessage }}</p>
-    <ul v-else>
-      <li v-for="item in items" :key="`${item.questionId}-${item.createdAt}`">
-        문제ID: {{ item.questionId }} / 등록일: {{ item.createdAt }}
-      </li>
-    </ul>
+
+    <LoadingState v-if="loading" message="즐겨찾기를 불러오는 중입니다..." />
+
+    <ErrorState
+      v-else-if="errorMessage"
+      :message="errorMessage"
+      :show-retry="true"
+      @retry="loadItems"
+    />
+
+    <template v-else>
+      <EmptyState v-if="items.length === 0" message="아직 즐겨찾기한 문제가 없습니다." />
+
+      <template v-else>
+        <ul class="list-view">
+          <li v-for="item in items" :key="`${item.questionId}-${item.createdAt}`" class="list-item">
+            <p><strong>문제ID:</strong> {{ item.questionId }}</p>
+            <p><strong>문장:</strong> {{ item.questionText }}</p>
+            <p><strong>카테고리:</strong> {{ item.category || "-" }}</p>
+            <p><strong>등록일:</strong> {{ item.createdAt }}</p>
+          </li>
+        </ul>
+
+        <div class="actions actions-left pager">
+          <button class="ghost" :disabled="page <= 1" @click="changePage(page - 1)">이전</button>
+          <span>{{ page }} / {{ totalPages }}</span>
+          <button class="ghost" :disabled="page >= totalPages" @click="changePage(page + 1)">다음</button>
+        </div>
+      </template>
+    </template>
   </section>
 </template>
 
@@ -21,13 +44,17 @@ import EmptyState from "../components/ui/EmptyState.vue";
 const items = ref([]);
 const loading = ref(false);
 const errorMessage = ref("");
+const page = ref(1);
+const size = 10;
+const totalPages = ref(1);
 
-onMounted(async () => {
+async function loadItems() {
   try {
     loading.value = true;
     errorMessage.value = "";
-    const page = await getFavorites();
-    items.value = page.content || [];
+    const data = await getFavorites(page.value, size);
+    items.value = data?.content || [];
+    totalPages.value = Math.max(data?.totalPages || 1, 1);
   } catch (error) {
     const status = error?.response?.status;
     if (status === 401) {
@@ -46,5 +73,12 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
-});
+}
+
+async function changePage(nextPage) {
+  page.value = nextPage;
+  await loadItems();
+}
+
+onMounted(loadItems);
 </script>

--- a/frontend/src/views/WrongAnswerListView.vue
+++ b/frontend/src/views/WrongAnswerListView.vue
@@ -1,13 +1,37 @@
 <template>
   <section class="card">
     <h2>오답노트</h2>
-    <p v-if="loading" class="muted">오답노트를 불러오는 중입니다...</p>
-    <p v-else-if="errorMessage" class="error">{{ errorMessage }}</p>
-    <ul v-else>
-      <li v-for="item in items" :key="`${item.questionId}-${item.lastWrongAt}`">
-        문제ID: {{ item.questionId }} / 오답횟수: {{ item.wrongCount }}
-      </li>
-    </ul>
+
+    <LoadingState v-if="loading" message="오답노트를 불러오는 중입니다..." />
+
+    <ErrorState
+      v-else-if="errorMessage"
+      :message="errorMessage"
+      :show-retry="true"
+      @retry="loadItems"
+    />
+
+    <template v-else>
+      <EmptyState v-if="items.length === 0" message="아직 오답노트 데이터가 없습니다." />
+
+      <template v-else>
+        <ul class="list-view">
+          <li v-for="item in items" :key="`${item.questionId}-${item.lastWrongAt}`" class="list-item">
+            <p><strong>문제ID:</strong> {{ item.questionId }}</p>
+            <p><strong>문장:</strong> {{ item.questionText }}</p>
+            <p><strong>카테고리:</strong> {{ item.category || "-" }}</p>
+            <p><strong>오답횟수:</strong> {{ item.wrongCount }}</p>
+            <p><strong>최근 오답:</strong> {{ item.lastWrongAt }}</p>
+          </li>
+        </ul>
+
+        <div class="actions actions-left pager">
+          <button class="ghost" :disabled="page <= 1" @click="changePage(page - 1)">이전</button>
+          <span>{{ page }} / {{ totalPages }}</span>
+          <button class="ghost" :disabled="page >= totalPages" @click="changePage(page + 1)">다음</button>
+        </div>
+      </template>
+    </template>
   </section>
 </template>
 
@@ -21,13 +45,17 @@ import EmptyState from "../components/ui/EmptyState.vue";
 const items = ref([]);
 const loading = ref(false);
 const errorMessage = ref("");
+const page = ref(1);
+const size = 10;
+const totalPages = ref(1);
 
-onMounted(async () => {
+async function loadItems() {
   try {
     loading.value = true;
     errorMessage.value = "";
-    const page = await getWrongAnswers();
-    items.value = page.content || [];
+    const data = await getWrongAnswers(page.value, size);
+    items.value = data?.content || [];
+    totalPages.value = Math.max(data?.totalPages || 1, 1);
   } catch (error) {
     const status = error?.response?.status;
     if (status === 401) {
@@ -46,5 +74,12 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
-});
+}
+
+async function changePage(nextPage) {
+  page.value = nextPage;
+  await loadItems();
+}
+
+onMounted(loadItems);
 </script>

--- a/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteCommandController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteCommandController.java
@@ -10,7 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/favorites")
+@RequestMapping({"/api/favorites", "/api/quiz/favorites"})
 @RequiredArgsConstructor
 // 즐겨찾기 등록/해제를 처리하는 커맨드 API입니다.
 public class FavoriteCommandController {

--- a/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteQueryController.java
+++ b/src/main/java/com/team/jpquiz/quiz/presentation/FavoriteQueryController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/favorites")
+@RequestMapping({"/api/favorites", "/api/quiz/favorites"})
 @RequiredArgsConstructor
 public class FavoriteQueryController {
 


### PR DESCRIPTION
  ## 작업 내용

  - 즐겨찾기 조회 API 경로를 백엔드 실 경로에 맞게 수정했습니다.
  - 백엔드는 즐겨찾기 API를 /api/favorites, /api/quiz/favorites 모두 수용하도록 호환 매핑을 추가했습니다.
  - 즐겨찾기/오답노트 목록 화면에 공통 UX를 적용했습니다.
      - 로딩 상태
      - 에러 상태(401/403/500 메시지)
      - 빈 상태
      - 페이지네이션(이전/다음)

  ## 변경 파일

  - frontend/src/api/favoriteApi.js
  - frontend/src/views/FavoriteListView.vue
  - frontend/src/views/WrongAnswerListView.vue
  - frontend/src/styles.css
  - src/main/java/com/team/jpquiz/quiz/presentation/FavoriteQueryController.java
  - src/main/java/com/team/jpquiz/quiz/presentation/FavoriteCommandController.java

  ## 검증

  - cd frontend && npm run build 통과
  - ./gradlew compileJava 통과