### PR TITLE
[Feat] 퀴즈 결과조회 UX 고도화

### DIFF
--- a/frontend/src/views/QuizResultView.vue
+++ b/frontend/src/views/QuizResultView.vue
@@ -8,6 +8,7 @@
     <h2>퀴즈 결과</h2>
     <p class="error">{{ errorMessage }}</p>
     <div class="actions actions-left">
+      <button class="ghost" @click="loadResult">다시 시도</button>
       <RouterLink class="btn-link secondary" to="/">홈으로</RouterLink>
       <RouterLink class="btn-link" to="/quiz/start">다시 풀기</RouterLink>
     </div>
@@ -19,8 +20,8 @@
       <li>총 문제 수: {{ result.totalQuestions }}</li>
       <li>제출 수: {{ result.solvedCount }}</li>
       <li>정답 수: {{ result.correctCount }}</li>
-      <li>정답률: {{ result.accuracy }}%</li>
-      <li>완료 시각: {{ result.completedAt }}</li>
+      <li>정답률: {{ formatAccuracy(result.accuracy) }}</li>
+      <li>완료 시각: {{ formatCompletedAt(result.completedAt) }}</li>
     </ul>
     <div class="actions actions-left">
       <RouterLink class="btn-link" to="/quiz/start">다시 풀기</RouterLink>
@@ -61,13 +62,34 @@ const isGuest = ref(false);
 const loading = ref(false);
 const errorMessage = ref("");
 
-onMounted(async () => {
+function formatAccuracy(value) {
+  if (typeof value !== "number") {
+    return "-";
+  }
+  return `${value}%`;
+}
+
+function formatCompletedAt(value) {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleString("ko-KR");
+}
+
+async function loadResult() {
   if (!isLoggedIn.value) {
     isGuest.value = true;
+    result.value = null;
+    errorMessage.value = "";
     return;
   }
 
   try {
+    isGuest.value = false;
     loading.value = true;
     errorMessage.value = "";
     result.value = await getResult(Number(route.params.attemptId));
@@ -93,5 +115,7 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
-});
+}
+
+onMounted(loadResult);
 </script>


### PR DESCRIPTION
 ## 작업 내용

  - 결과 조회 화면의 실패 상태에 다시 시도 액션을 추가했습니다.
  - 정답률/완료 시각 표시를 사용자 친화적으로 포맷팅했습니다.
  - 결과 조회 로직을 함수(loadResult)로 분리해 초기 진입과 재시도를 동일 흐름으로 처리하도록 정리했습니다.
  - 비회원 분기 시 결과/오류 상태가 섞이지 않도록 상태 초기화를 보강했습니다.

  ## 변경 파일

  - frontend/src/views/QuizResultView.vue

  ## 확인 방법

  1. 결과 화면 진입 시 정상 카드 노출 확인
  2. 네트워크 오류 상황에서 오류 문구 + 다시 시도 버튼 동작 확인
  3. 완료 시각이 로컬 시간 형식으로 표시되는지 확인
  4. 비회원 진입 시 로그인/회원가입 유도 모달 노출 확인