### PR TITLE
[Feat] 통계 1~4 구현

### DIFF
--- a/src/main/java/com/team/jpquiz/stats/dto/response/StatsResponse.java
+++ b/src/main/java/com/team/jpquiz/stats/dto/response/StatsResponse.java
@@ -38,4 +38,61 @@ public class StatsResponse {
         private double completionRate;
         private double accuracyRate;
     }
+<<<<<<< Updated upstream
+=======
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryAccuracy {
+        private String category;
+        private int totalAnswers;
+        private int correctAnswers;
+        private double accuracyRate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionStats {
+        private Long questionId;
+        private String questionText;
+        private String category;
+        private int totalAnswers;
+        private int correctAnswers;
+        private int wrongAnswers;
+        private double accuracyRate;
+        private double difficultyScore;
+        private String difficultyLevel;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TopWrongQuestion {
+        private Long questionId;
+        private String questionText;
+        private String category;
+        private int totalAnswers;
+        private int wrongAnswers;
+        private double wrongRate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LearningRanking {
+        private int rank;
+        private Long memberId;
+        private String nickname;
+        private int totalAnswers;
+        private int completedAttempts;
+        private int correctAnswers;
+        private double accuracyRate;
+    }
+>>>>>>> Stashed changes
 }

--- a/src/main/java/com/team/jpquiz/stats/presentation/StatsController.java
+++ b/src/main/java/com/team/jpquiz/stats/presentation/StatsController.java
@@ -1,13 +1,25 @@
 package com.team.jpquiz.stats.presentation;
 
 import com.team.jpquiz.common.dto.ApiResponse;
+<<<<<<< Updated upstream
 import com.team.jpquiz.common.util.SecurityUtil;
 import com.team.jpquiz.stats.dto.response.StatsResponse;
 import com.team.jpquiz.stats.query.application.StatsQueryService;
+=======
+import com.team.jpquiz.common.dto.PageResponse;
+import com.team.jpquiz.common.util.SecurityUtil;
+import com.team.jpquiz.stats.dto.response.StatsResponse;
+import com.team.jpquiz.stats.query.application.StatsQueryService;
+import java.util.List;
+>>>>>>> Stashed changes
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+<<<<<<< Updated upstream
+=======
+import org.springframework.web.bind.annotation.RequestParam;
+>>>>>>> Stashed changes
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,4 +42,46 @@ public class StatsController {
         StatsResponse.AdminOverview response = statsQueryService.getAdminOverview();
         return ApiResponse.ok(response);
     }
+<<<<<<< Updated upstream
+=======
+
+    @GetMapping("/admin/stats/categories")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<List<StatsResponse.CategoryAccuracy>> getCategoryAccuracy(
+            @RequestParam(defaultValue = "latest") String basis
+    ) {
+        List<StatsResponse.CategoryAccuracy> response = statsQueryService.findCategoryAccuracy(basis);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/admin/stats/questions")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<PageResponse<StatsResponse.QuestionStats>> getQuestionStats(
+            @RequestParam(defaultValue = "first") String basis,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageResponse<StatsResponse.QuestionStats> response =
+                statsQueryService.findQuestionStats(basis, page, size);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/admin/stats/questions/top-wrong")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<List<StatsResponse.TopWrongQuestion>> getTopWrongQuestions(
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        List<StatsResponse.TopWrongQuestion> response = statsQueryService.findTopWrongQuestions(limit);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/admin/stats/rankings/learning")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<List<StatsResponse.LearningRanking>> getLearningRanking(
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        List<StatsResponse.LearningRanking> response = statsQueryService.findLearningRanking(limit);
+        return ApiResponse.ok(response);
+    }
+>>>>>>> Stashed changes
 }

--- a/src/main/java/com/team/jpquiz/stats/query/infrastructure/StatsMapper.java
+++ b/src/main/java/com/team/jpquiz/stats/query/infrastructure/StatsMapper.java
@@ -1,6 +1,10 @@
 package com.team.jpquiz.stats.query.infrastructure;
 
 import com.team.jpquiz.stats.dto.response.StatsResponse;
+<<<<<<< Updated upstream
+=======
+import java.util.List;
+>>>>>>> Stashed changes
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -10,4 +14,29 @@ public interface StatsMapper {
     StatsResponse.MyStats findMyStats(@Param("memberId") Long memberId);
 
     StatsResponse.AdminOverview findAdminOverview();
+<<<<<<< Updated upstream
+=======
+
+    List<StatsResponse.CategoryAccuracy> findCategoryAccuracyByLatest();
+
+    List<StatsResponse.CategoryAccuracy> findCategoryAccuracyByFirst();
+
+    List<StatsResponse.QuestionStats> findQuestionStatsByLatest(
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    long countQuestionStatsByLatest();
+
+    List<StatsResponse.QuestionStats> findQuestionStatsByFirst(
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    long countQuestionStatsByFirst();
+
+    List<StatsResponse.TopWrongQuestion> findTopWrongQuestions(@Param("limit") int limit);
+
+    List<StatsResponse.LearningRanking> findLearningRanking(@Param("limit") int limit);
+>>>>>>> Stashed changes
 }

--- a/src/main/resources/mappers/stats/StatsMapper.xml
+++ b/src/main/resources/mappers/stats/StatsMapper.xml
@@ -46,4 +46,196 @@
              FROM quiz_attempts
              WHERE started_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)) AS activeUsers7d
     </select>
+<<<<<<< Updated upstream
+=======
+
+    <select id="findCategoryAccuracyByLatest" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$CategoryAccuracy">
+        WITH ranked_answers AS (
+            SELECT
+                qa.user_id AS userId,
+                qaa.question_id AS questionId,
+                qaa.is_correct AS isCorrect,
+                ROW_NUMBER() OVER (
+                    PARTITION BY qa.user_id, qaa.question_id
+                    ORDER BY qaa.answered_at DESC, qaa.attempt_id DESC, qaa.seq DESC
+                ) AS rn
+            FROM quiz_attempt_answers qaa
+            JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+            WHERE qa.user_id IS NOT NULL
+        )
+        SELECT
+            COALESCE(qs.name, 'UNCATEGORIZED') AS category,
+            COUNT(*) AS totalAnswers,
+            SUM(CASE WHEN ra.isCorrect = 1 THEN 1 ELSE 0 END) AS correctAnswers
+        FROM ranked_answers ra
+        JOIN quiz_questions qq ON qq.question_id = ra.questionId
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
+        WHERE ra.rn = 1
+        GROUP BY COALESCE(qs.name, 'UNCATEGORIZED')
+        ORDER BY totalAnswers DESC, category ASC
+    </select>
+
+    <select id="findCategoryAccuracyByFirst" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$CategoryAccuracy">
+        WITH ranked_answers AS (
+            SELECT
+                qa.user_id AS userId,
+                qaa.question_id AS questionId,
+                qaa.is_correct AS isCorrect,
+                ROW_NUMBER() OVER (
+                    PARTITION BY qa.user_id, qaa.question_id
+                    ORDER BY qaa.answered_at ASC, qaa.attempt_id ASC, qaa.seq ASC
+                ) AS rn
+            FROM quiz_attempt_answers qaa
+            JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+            WHERE qa.user_id IS NOT NULL
+        )
+        SELECT
+            COALESCE(qs.name, 'UNCATEGORIZED') AS category,
+            COUNT(*) AS totalAnswers,
+            SUM(CASE WHEN ra.isCorrect = 1 THEN 1 ELSE 0 END) AS correctAnswers
+        FROM ranked_answers ra
+        JOIN quiz_questions qq ON qq.question_id = ra.questionId
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
+        WHERE ra.rn = 1
+        GROUP BY COALESCE(qs.name, 'UNCATEGORIZED')
+        ORDER BY totalAnswers DESC, category ASC
+    </select>
+
+    <select id="findQuestionStatsByLatest" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$QuestionStats">
+        WITH ranked_answers AS (
+            SELECT
+                qa.user_id AS userId,
+                qaa.question_id AS questionId,
+                qaa.is_correct AS isCorrect,
+                ROW_NUMBER() OVER (
+                    PARTITION BY qa.user_id, qaa.question_id
+                    ORDER BY qaa.answered_at DESC, qaa.attempt_id DESC, qaa.seq DESC
+                ) AS rn
+            FROM quiz_attempt_answers qaa
+            JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+            WHERE qa.user_id IS NOT NULL
+        )
+        SELECT
+            qq.question_id AS questionId,
+            qq.question_text AS questionText,
+            COALESCE(qs.name, 'UNCATEGORIZED') AS category,
+            COUNT(*) AS totalAnswers,
+            SUM(CASE WHEN ra.isCorrect = 1 THEN 1 ELSE 0 END) AS correctAnswers,
+            SUM(CASE WHEN ra.isCorrect = 0 THEN 1 ELSE 0 END) AS wrongAnswers
+        FROM ranked_answers ra
+        JOIN quiz_questions qq ON qq.question_id = ra.questionId
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
+        WHERE ra.rn = 1
+        GROUP BY qq.question_id, qq.question_text, COALESCE(qs.name, 'UNCATEGORIZED')
+        ORDER BY wrongAnswers DESC, totalAnswers DESC, qq.question_id ASC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countQuestionStatsByLatest" resultType="long">
+        WITH ranked_answers AS (
+            SELECT
+                qa.user_id AS userId,
+                qaa.question_id AS questionId,
+                ROW_NUMBER() OVER (
+                    PARTITION BY qa.user_id, qaa.question_id
+                    ORDER BY qaa.answered_at DESC, qaa.attempt_id DESC, qaa.seq DESC
+                ) AS rn
+            FROM quiz_attempt_answers qaa
+            JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+            WHERE qa.user_id IS NOT NULL
+        )
+        SELECT COUNT(*)
+        FROM (
+            SELECT ra.questionId
+            FROM ranked_answers ra
+            WHERE ra.rn = 1
+            GROUP BY ra.questionId
+        ) t
+    </select>
+
+    <select id="findQuestionStatsByFirst" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$QuestionStats">
+        WITH ranked_answers AS (
+            SELECT
+                qa.user_id AS userId,
+                qaa.question_id AS questionId,
+                qaa.is_correct AS isCorrect,
+                ROW_NUMBER() OVER (
+                    PARTITION BY qa.user_id, qaa.question_id
+                    ORDER BY qaa.answered_at ASC, qaa.attempt_id ASC, qaa.seq ASC
+                ) AS rn
+            FROM quiz_attempt_answers qaa
+            JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+            WHERE qa.user_id IS NOT NULL
+        )
+        SELECT
+            qq.question_id AS questionId,
+            qq.question_text AS questionText,
+            COALESCE(qs.name, 'UNCATEGORIZED') AS category,
+            COUNT(*) AS totalAnswers,
+            SUM(CASE WHEN ra.isCorrect = 1 THEN 1 ELSE 0 END) AS correctAnswers,
+            SUM(CASE WHEN ra.isCorrect = 0 THEN 1 ELSE 0 END) AS wrongAnswers
+        FROM ranked_answers ra
+        JOIN quiz_questions qq ON qq.question_id = ra.questionId
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
+        WHERE ra.rn = 1
+        GROUP BY qq.question_id, qq.question_text, COALESCE(qs.name, 'UNCATEGORIZED')
+        ORDER BY wrongAnswers DESC, totalAnswers DESC, qq.question_id ASC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countQuestionStatsByFirst" resultType="long">
+        WITH ranked_answers AS (
+            SELECT
+                qa.user_id AS userId,
+                qaa.question_id AS questionId,
+                ROW_NUMBER() OVER (
+                    PARTITION BY qa.user_id, qaa.question_id
+                    ORDER BY qaa.answered_at ASC, qaa.attempt_id ASC, qaa.seq ASC
+                ) AS rn
+            FROM quiz_attempt_answers qaa
+            JOIN quiz_attempts qa ON qa.attempt_id = qaa.attempt_id
+            WHERE qa.user_id IS NOT NULL
+        )
+        SELECT COUNT(*)
+        FROM (
+            SELECT ra.questionId
+            FROM ranked_answers ra
+            WHERE ra.rn = 1
+            GROUP BY ra.questionId
+        ) t
+    </select>
+
+    <select id="findTopWrongQuestions" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$TopWrongQuestion">
+        SELECT
+            qq.question_id AS questionId,
+            qq.question_text AS questionText,
+            COALESCE(qs.name, 'UNCATEGORIZED') AS category,
+            COUNT(*) AS totalAnswers,
+            SUM(CASE WHEN qaa.is_correct = 0 THEN 1 ELSE 0 END) AS wrongAnswers
+        FROM quiz_attempt_answers qaa
+        JOIN quiz_questions qq ON qq.question_id = qaa.question_id
+        LEFT JOIN quiz_scenes qs ON qs.scene_id = qq.scene_id
+        GROUP BY qq.question_id, qq.question_text, COALESCE(qs.name, 'UNCATEGORIZED')
+        HAVING SUM(CASE WHEN qaa.is_correct = 0 THEN 1 ELSE 0 END) > 0
+        ORDER BY wrongAnswers DESC, totalAnswers DESC, qq.question_id ASC
+        LIMIT #{limit}
+    </select>
+
+    <select id="findLearningRanking" resultType="com.team.jpquiz.stats.dto.response.StatsResponse$LearningRanking">
+        SELECT
+            qa.user_id AS memberId,
+            COALESCE(u.nickname, CONCAT('USER-', qa.user_id)) AS nickname,
+            COUNT(qaa.attempt_id) AS totalAnswers,
+            COUNT(DISTINCT CASE WHEN qa.completed_at IS NOT NULL THEN qa.attempt_id END) AS completedAttempts,
+            SUM(CASE WHEN qaa.is_correct = 1 THEN 1 ELSE 0 END) AS correctAnswers
+        FROM quiz_attempts qa
+        LEFT JOIN quiz_attempt_answers qaa ON qaa.attempt_id = qa.attempt_id
+        LEFT JOIN users u ON u.user_id = qa.user_id
+        WHERE qa.user_id IS NOT NULL
+        GROUP BY qa.user_id, COALESCE(u.nickname, CONCAT('USER-', qa.user_id))
+        HAVING COUNT(qaa.attempt_id) > 0
+        ORDER BY totalAnswers DESC, completedAttempts DESC, correctAnswers DESC, qa.user_id ASC
+        LIMIT #{limit}
+    </select>
+>>>>>>> Stashed changes
 </mapper>


### PR DESCRIPTION
 ## 작업 내용
  - 통계(Statistics, 통계) 기능 구현
  - 개인 통계 API(Application Programming Interface, 응용 프로그램 인터페이스) 및 관리자 통계 API 추가
  - 카테고리/문제/오답 TOP N/학습량 랭킹 집계 로직 추가

  ## 상세 변경 사항
  - Controller(컨트롤러)
    - `GET /api/stats/me`
    - `GET /api/admin/stats/overview`
    - `GET /api/admin/stats/categories`
    - `GET /api/admin/stats/questions`
    - `GET /api/admin/stats/questions/top-wrong`
    - `GET /api/admin/stats/rankings/learning`
  - Service(서비스)
    - basis(`first`/`latest`) 처리
    - 정답률/난이도/오답률 계산 로직 반영
    - 페이징/limit 유효성 검증 추가
  - Mapper(MyBatis, 마이바티스)
    - 카테고리별 정답률
    - 문제별 정답률/난이도
    - 가장 많이 틀린 TOP N
    - 유저별 학습량 랭킹
  - DTO(Data Transfer Object, 데이터 전송 객체)
    - `StatsResponse` 하위 응답 타입 추가/정리

  ## 테스트 방법
  1. 관리자 토큰으로 통계 API 호출
  2. `basis=first/latest` 파라미터 변경 후 응답 비교
  3. `page/size/limit` 경계값 테스트(예: 0, 101)
  4. 비관리자 계정으로 `/api/admin/stats/**` 호출 시 403 확인
  5. 데이터 없는 환경에서 0값 반환 확인