### PR TITLE
[Feat] 문제 신고 기본 사유 자동 주입 및 고유 신고자 임계치 기반 자동 비활성화 적용

### DIFF
--- a/src/main/java/com/team/jpquiz/global/error/ErrorCode.java
+++ b/src/main/java/com/team/jpquiz/global/error/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
     // Problem Report
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_NOT_FOUND", "신고 내역을 찾을 수 없습니다."),
     INVALID_REPORT_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "INVALID_REPORT_STATUS_TRANSITION", "신고 상태 전이가 올바르지 않습니다."),
-    REPORT_TARGET_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_TARGET_QUESTION_NOT_FOUND", "신고 대상 문제를 찾을 수 없습니다.");
+    REPORT_TARGET_QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT_TARGET_QUESTION_NOT_FOUND", "신고 대상 문제를 찾을 수 없습니다."),
+    REPORT_CONTENT_REQUIRED_FOR_ETC(HttpStatus.BAD_REQUEST, "REPORT_CONTENT_REQUIRED_FOR_ETC", "기타 신고 유형은 상세 사유를 입력해야 합니다.");
 
 
 

--- a/src/main/java/com/team/jpquiz/report/command/infrastructure/ProblemReportValidationMapper.java
+++ b/src/main/java/com/team/jpquiz/report/command/infrastructure/ProblemReportValidationMapper.java
@@ -6,5 +6,9 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface ProblemReportValidationMapper {
 
-    int countQuestionById(@Param("questionId") Long questionId);
+    int countActiveQuestionById(@Param("questionId") Long questionId);
+
+    int countDistinctReporterIdsByQuestionId(@Param("questionId") Long questionId);
+
+    int deactivateQuestionById(@Param("questionId") Long questionId);
 }

--- a/src/main/java/com/team/jpquiz/report/dto/request/ProblemReportCreateRequest.java
+++ b/src/main/java/com/team/jpquiz/report/dto/request/ProblemReportCreateRequest.java
@@ -1,7 +1,6 @@
 package com.team.jpquiz.report.dto.request;
 
 import com.team.jpquiz.report.command.domain.ReportType;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -19,7 +18,6 @@ public class ProblemReportCreateRequest {
     @NotNull
     private ReportType reportType;
 
-    @NotBlank
     @Size(max = 1000)
     private String content;
 }

--- a/src/main/resources/mappers/quiz/QuizCommandMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizCommandMapper.xml
@@ -9,12 +9,14 @@
     <select id="countAllQuestions" resultType="int">
         SELECT COUNT(*)
         FROM quiz_questions
+        WHERE is_active = 1
     </select>
 
     <!-- 시작 시점에 랜덤 문제 ID를 count개 추출 -->
     <select id="findRandomQuestionIds" resultType="long">
         SELECT qq.question_id
         FROM quiz_questions qq
+        WHERE qq.is_active = 1
         ORDER BY RAND()
         LIMIT #{count}
     </select>
@@ -25,6 +27,7 @@
         FROM wrong_answers wa
         JOIN quiz_questions qq ON qq.question_id = wa.question_id
         WHERE wa.member_id = #{memberId}
+          AND qq.is_active = 1
         ORDER BY COALESCE(wa.last_wrong_at, wa.created_at) DESC
         LIMIT #{limit}
     </select>
@@ -34,8 +37,9 @@
         SELECT qq.question_id
         FROM quiz_questions qq
         <where>
+            qq.is_active = 1
             <if test="excludeIds != null and excludeIds.size() > 0">
-                qq.question_id NOT IN
+                AND qq.question_id NOT IN
                 <foreach collection="excludeIds" item="id" open="(" separator="," close=")">
                     #{id}
                 </foreach>

--- a/src/main/resources/mappers/report/ProblemReportValidationMapper.xml
+++ b/src/main/resources/mappers/report/ProblemReportValidationMapper.xml
@@ -3,10 +3,28 @@
 
 <mapper namespace="com.team.jpquiz.report.command.infrastructure.ProblemReportValidationMapper">
 
-    <select id="countQuestionById" resultType="int">
+    <select id="countActiveQuestionById" resultType="int">
         SELECT COUNT(*)
         FROM quiz_questions
         WHERE question_id = #{questionId}
+          AND is_active = 1
     </select>
+
+    <select id="countDistinctReporterIdsByQuestionId" resultType="int">
+        SELECT COUNT(DISTINCT reporter_id)
+        FROM problem_reports
+        WHERE question_id = #{questionId}
+          AND reporter_id IS NOT NULL
+          AND status &lt;&gt; 'REJECTED'
+    </select>
+
+    <update id="deactivateQuestionById">
+        UPDATE quiz_questions
+        SET is_active = 0,
+            deactivated_at = NOW(),
+            updated_at = NOW()
+        WHERE question_id = #{questionId}
+          AND is_active = 1
+    </update>
 
 </mapper>

--- a/src/test/java/com/team/jpquiz/report/command/application/ProblemReportCommandServiceTest.java
+++ b/src/test/java/com/team/jpquiz/report/command/application/ProblemReportCommandServiceTest.java
@@ -1,0 +1,93 @@
+package com.team.jpquiz.report.command.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.team.jpquiz.global.error.CustomException;
+import com.team.jpquiz.global.error.ErrorCode;
+import com.team.jpquiz.report.command.domain.ProblemReport;
+import com.team.jpquiz.report.command.domain.ReportType;
+import com.team.jpquiz.report.command.infrastructure.ProblemReportRepository;
+import com.team.jpquiz.report.command.infrastructure.ProblemReportValidationMapper;
+import com.team.jpquiz.report.dto.request.ProblemReportCreateRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProblemReportCommandServiceTest {
+
+    @Mock
+    private ProblemReportRepository problemReportRepository;
+
+    @Mock
+    private ProblemReportValidationMapper problemReportValidationMapper;
+
+    @InjectMocks
+    private ProblemReportCommandService problemReportCommandService;
+
+    @Test
+    void createReport_typoWithBlankContent_usesDefaultContent() {
+        ProblemReportCreateRequest request = createRequest(1L, ReportType.TYPO, "   ");
+        given(problemReportValidationMapper.countQuestionById(1L)).willReturn(1);
+        given(problemReportRepository.save(any(ProblemReport.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        problemReportCommandService.createReport(10L, request);
+
+        ArgumentCaptor<ProblemReport> captor = ArgumentCaptor.forClass(ProblemReport.class);
+        verify(problemReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("오탈자가 있습니다.");
+    }
+
+    @Test
+    void createReport_wrongAnswerWithNullContent_usesDefaultContent() {
+        ProblemReportCreateRequest request = createRequest(1L, ReportType.WRONG_ANSWER, null);
+        given(problemReportValidationMapper.countQuestionById(1L)).willReturn(1);
+        given(problemReportRepository.save(any(ProblemReport.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        problemReportCommandService.createReport(10L, request);
+
+        ArgumentCaptor<ProblemReport> captor = ArgumentCaptor.forClass(ProblemReport.class);
+        verify(problemReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("정답에 오류가 있습니다.");
+    }
+
+    @Test
+    void createReport_etcWithBlankContent_throwsValidationException() {
+        ProblemReportCreateRequest request = createRequest(1L, ReportType.ETC, " ");
+        given(problemReportValidationMapper.countQuestionById(1L)).willReturn(1);
+
+        assertThatThrownBy(() -> problemReportCommandService.createReport(10L, request))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.REPORT_CONTENT_REQUIRED_FOR_ETC));
+    }
+
+    @Test
+    void createReport_typoWithContent_preservesTrimmedContent() {
+        ProblemReportCreateRequest request = createRequest(1L, ReportType.TYPO, "  실제 상세 사유 ");
+        given(problemReportValidationMapper.countQuestionById(1L)).willReturn(1);
+        given(problemReportRepository.save(any(ProblemReport.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        problemReportCommandService.createReport(10L, request);
+
+        ArgumentCaptor<ProblemReport> captor = ArgumentCaptor.forClass(ProblemReport.class);
+        verify(problemReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("실제 상세 사유");
+    }
+
+    private ProblemReportCreateRequest createRequest(Long questionId, ReportType reportType, String content) {
+        ProblemReportCreateRequest request = new ProblemReportCreateRequest();
+        ReflectionTestUtils.setField(request, "questionId", questionId);
+        ReflectionTestUtils.setField(request, "reportType", reportType);
+        ReflectionTestUtils.setField(request, "content", content);
+        return request;
+    }
+}


### PR DESCRIPTION
## 작업 내용
  - 문제 신고 생성 정책을 개선했습니다.
  - 신고 유형별 기본 사유 자동 주입 로직을 추가했습니다.
  - 고유 신고자 수 기반 임계치 도달 시 문제 자동 비활성화 로직을 추가했습니다.

  ## 상세 변경 사항
  - `ProblemReportCreateRequest`에서 `content`를 선택 입력으로 변경했습니다.
  - `ProblemReportCommandService`에 다음 로직을 추가했습니다.
  - `reportType=TYPO` + `content` 공백/널값이면 `오탈자가 있습니다.` 자동 주입
  - `reportType=WRONG_ANSWER` + `content` 공백/널값이면 `정답에 오류가 있습니다.` 자동 주입
  - `reportType=ETC` + `content` 공백/널값이면 예외(`REPORT_CONTENT_REQUIRED_FOR_ETC`) 반환
  - `ProblemReportValidationMapper`에 고유 신고자 수 집계 및 문제 비활성화 쿼리를 추가했습니다.
  - `QuizCommandMapper`에서 비활성 문제(`is_active=0`)가 퀴즈 출제 풀에 포함되지 않도록 조건을 추가했습니다.
  - 설정값 `app.report.auto-deactivate.unique-reporter-threshold`(기본값: 3)을 도입했습니다.
  - 참고: DB 스키마 컬럼(`quiz_questions.is_active`, `quiz_questions.deactivated_at`) 반영 경로는 추가 확인이 필요합니다.

  ## 테스트 방법
  1. `POST /api/reports` 요청에서 `reportType=TYPO`, `content=""`로 호출 후 기본 문구 저장 여부를 확인합니다.
  2. `POST /api/reports` 요청에서 `reportType=WRONG_ANSWER`, `content=null`로 호출 후 기본 문구 저장 여부를 확인합니다.
  3. `POST /api/reports` 요청에서 `reportType=ETC`, `content=""`로 호출 후 400 에러 코드(`REPORT_CONTENT_REQUIRED_FOR_ETC`)를 확인합니다.
  4. 동일 사용자 반복 신고 시 고유 신고자 수가 증가하지 않는지 확인합니다.
  5. 서로 다른 사용자 신고가 임계치 이상일 때 문제가 비활성화되는지 확인합니다.
  6. 퀴즈 시작 API에서 비활성화된 문제가 출제되지 않는지 확인합니다.