### PR TITLE
[Feat] 통계(Stats) API 연동 및 화면 구현 (학습 랭킹 제외)

### DIFF
--- a/frontend/src/api/statsApi.js
+++ b/frontend/src/api/statsApi.js
@@ -4,3 +4,29 @@ export async function getMyStats() {
   const response = await http.get("/api/stats/me");
   return unwrap(response);
 }
+
+export async function getAdminOverview() {
+  const response = await http.get("/api/admin/stats/overview");
+  return unwrap(response);
+}
+
+export async function getCategoryAccuracy(basis = "latest") {
+  const response = await http.get("/api/admin/stats/categories", {
+    params: { basis }
+  });
+  return unwrap(response);
+}
+
+export async function getQuestionStats({ basis = "first", page = 1, size = 10 } = {}) {
+  const response = await http.get("/api/admin/stats/questions", {
+    params: { basis, page, size }
+  });
+  return unwrap(response);
+}
+
+export async function getTopWrongQuestions(limit = 10) {
+  const response = await http.get("/api/admin/stats/questions/top-wrong", {
+    params: { limit }
+  });
+  return unwrap(response);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -263,3 +263,42 @@ ruby rt {
   font-size: 11px;
   color: #475569;
 }
+
+.admin-section + .admin-section {
+  margin-top: 20px;
+}
+
+.admin-stats-filters {
+  margin: 12px 0 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.field-inline {
+  display: grid;
+  gap: 6px;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.stat-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.stat-label {
+  margin: 0;
+  font-size: 13px;
+  color: #475569;
+}
+
+.stat-value {
+  margin: 8px 0 0;
+  font-size: 22px;
+  font-weight: 700;
+}

--- a/frontend/src/views/AdminStatsView.vue
+++ b/frontend/src/views/AdminStatsView.vue
@@ -1,6 +1,287 @@
 <template>
   <section class="card">
     <h2>관리자 통계</h2>
-    <p class="muted">관리자 통계 대시보드 화면입니다.</p>
+
+    <div class="form admin-stats-filters">
+      <div class="field-inline">
+        <label for="basis">기준</label>
+        <select id="basis" v-model="basis" @change="reloadAll">
+          <option value="latest">latest</option>
+          <option value="first">first</option>
+        </select>
+      </div>
+      <div class="field-inline">
+        <label for="size">문항 size</label>
+        <select id="size" v-model.number="size" @change="onSizeChange">
+          <option :value="10">10</option>
+          <option :value="20">20</option>
+          <option :value="50">50</option>
+        </select>
+      </div>
+      <div class="field-inline">
+        <label for="limit">오답 TOP</label>
+        <select id="limit" v-model.number="limit" @change="loadTopWrong">
+          <option :value="5">5</option>
+          <option :value="10">10</option>
+          <option :value="20">20</option>
+        </select>
+      </div>
+    </div>
+
+    <section class="admin-section">
+      <h3>개요</h3>
+      <LoadingState v-if="overviewLoading" message="개요를 불러오는 중입니다..." />
+      <ErrorState
+        v-else-if="overviewError"
+        :message="overviewError"
+        :show-retry="true"
+        @retry="loadOverview"
+      />
+      <div v-else class="stats-grid">
+        <article class="stat-card">
+          <p class="stat-label">총 시도</p>
+          <p class="stat-value">{{ overview.totalAttempts }}</p>
+        </article>
+        <article class="stat-card">
+          <p class="stat-label">완료 시도</p>
+          <p class="stat-value">{{ overview.completedAttempts }}</p>
+        </article>
+        <article class="stat-card">
+          <p class="stat-label">총 제출</p>
+          <p class="stat-value">{{ overview.totalAnswers }}</p>
+        </article>
+        <article class="stat-card">
+          <p class="stat-label">정답 수</p>
+          <p class="stat-value">{{ overview.correctAnswers }}</p>
+        </article>
+        <article class="stat-card">
+          <p class="stat-label">완료율</p>
+          <p class="stat-value">{{ overview.completionRate }}%</p>
+        </article>
+        <article class="stat-card">
+          <p class="stat-label">정답률</p>
+          <p class="stat-value">{{ overview.accuracyRate }}%</p>
+        </article>
+        <article class="stat-card">
+          <p class="stat-label">최근 7일 활성 유저</p>
+          <p class="stat-value">{{ overview.activeUsers7d }}</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="admin-section">
+      <h3>카테고리 정확도</h3>
+      <LoadingState v-if="categoriesLoading" message="카테고리 통계를 불러오는 중입니다..." />
+      <ErrorState
+        v-else-if="categoriesError"
+        :message="categoriesError"
+        :show-retry="true"
+        @retry="loadCategories"
+      />
+      <EmptyState v-else-if="categories.length === 0" message="카테고리 통계 데이터가 없습니다." />
+      <ul v-else class="list-view">
+        <li v-for="item in categories" :key="item.category" class="list-item">
+          <p><strong>카테고리:</strong> {{ item.category }}</p>
+          <p><strong>총 답변:</strong> {{ item.totalAnswers }}</p>
+          <p><strong>정답:</strong> {{ item.correctAnswers }}</p>
+          <p><strong>정답률:</strong> {{ item.accuracyRate }}%</p>
+        </li>
+      </ul>
+    </section>
+
+    <section class="admin-section">
+      <h3>문항 통계</h3>
+      <LoadingState v-if="questionsLoading" message="문항 통계를 불러오는 중입니다..." />
+      <ErrorState
+        v-else-if="questionsError"
+        :message="questionsError"
+        :show-retry="true"
+        @retry="loadQuestions"
+      />
+      <EmptyState
+        v-else-if="questionPage.content.length === 0"
+        message="문항 통계 데이터가 없습니다."
+      />
+      <template v-else>
+        <ul class="list-view">
+          <li v-for="item in questionPage.content" :key="item.questionId" class="list-item">
+            <p><strong>문제ID:</strong> {{ item.questionId }}</p>
+            <p><strong>문장:</strong> {{ item.questionText }}</p>
+            <p><strong>카테고리:</strong> {{ item.category || "-" }}</p>
+            <p><strong>총 답변:</strong> {{ item.totalAnswers }}</p>
+            <p><strong>정답/오답:</strong> {{ item.correctAnswers }} / {{ item.wrongAnswers }}</p>
+            <p><strong>정답률:</strong> {{ item.accuracyRate }}%</p>
+            <p><strong>난이도:</strong> {{ item.difficultyLevel }} ({{ item.difficultyScore }})</p>
+          </li>
+        </ul>
+        <div class="actions actions-left pager">
+          <button class="ghost" :disabled="page <= 1" @click="changePage(page - 1)">이전</button>
+          <span>{{ page }} / {{ totalPages }}</span>
+          <button class="ghost" :disabled="page >= totalPages" @click="changePage(page + 1)">다음</button>
+        </div>
+      </template>
+    </section>
+
+    <section class="admin-section">
+      <h3>오답 TOP</h3>
+      <LoadingState v-if="topWrongLoading" message="오답 TOP 통계를 불러오는 중입니다..." />
+      <ErrorState
+        v-else-if="topWrongError"
+        :message="topWrongError"
+        :show-retry="true"
+        @retry="loadTopWrong"
+      />
+      <EmptyState v-else-if="topWrongItems.length === 0" message="오답 TOP 데이터가 없습니다." />
+      <ul v-else class="list-view">
+        <li v-for="item in topWrongItems" :key="item.questionId" class="list-item">
+          <p><strong>문제ID:</strong> {{ item.questionId }}</p>
+          <p><strong>문장:</strong> {{ item.questionText }}</p>
+          <p><strong>카테고리:</strong> {{ item.category || "-" }}</p>
+          <p><strong>오답/총답변:</strong> {{ item.wrongAnswers }} / {{ item.totalAnswers }}</p>
+          <p><strong>오답률:</strong> {{ item.wrongRate }}%</p>
+        </li>
+      </ul>
+    </section>
   </section>
 </template>
+
+<script setup>
+import { onMounted, reactive, ref } from "vue";
+import {
+  getAdminOverview,
+  getCategoryAccuracy,
+  getQuestionStats,
+  getTopWrongQuestions
+} from "../api/statsApi";
+import LoadingState from "../components/ui/LoadingState.vue";
+import ErrorState from "../components/ui/ErrorState.vue";
+import EmptyState from "../components/ui/EmptyState.vue";
+
+const basis = ref("latest");
+const page = ref(1);
+const size = ref(10);
+const limit = ref(10);
+
+const overview = reactive({
+  totalAttempts: 0,
+  completedAttempts: 0,
+  totalAnswers: 0,
+  correctAnswers: 0,
+  activeUsers7d: 0,
+  completionRate: 0,
+  accuracyRate: 0
+});
+const categories = ref([]);
+const questionPage = reactive({
+  content: [],
+  totalPages: 1
+});
+const topWrongItems = ref([]);
+
+const overviewLoading = ref(false);
+const categoriesLoading = ref(false);
+const questionsLoading = ref(false);
+const topWrongLoading = ref(false);
+
+const overviewError = ref("");
+const categoriesError = ref("");
+const questionsError = ref("");
+const topWrongError = ref("");
+
+const totalPages = ref(1);
+
+function toErrorMessage(error, defaultMessage) {
+  const status = error?.response?.status;
+  if (status === 400) {
+    return "요청 값이 올바르지 않습니다.";
+  }
+  if (status === 401) {
+    return "로그인이 필요합니다.";
+  }
+  if (status === 403) {
+    return "접근 권한이 없습니다.";
+  }
+  return defaultMessage;
+}
+
+async function loadOverview() {
+  try {
+    overviewLoading.value = true;
+    overviewError.value = "";
+    const data = await getAdminOverview();
+    overview.totalAttempts = data?.totalAttempts ?? 0;
+    overview.completedAttempts = data?.completedAttempts ?? 0;
+    overview.totalAnswers = data?.totalAnswers ?? 0;
+    overview.correctAnswers = data?.correctAnswers ?? 0;
+    overview.activeUsers7d = data?.activeUsers7d ?? 0;
+    overview.completionRate = data?.completionRate ?? 0;
+    overview.accuracyRate = data?.accuracyRate ?? 0;
+  } catch (error) {
+    overviewError.value = toErrorMessage(error, "관리자 개요 통계를 불러오지 못했습니다.");
+  } finally {
+    overviewLoading.value = false;
+  }
+}
+
+async function loadCategories() {
+  try {
+    categoriesLoading.value = true;
+    categoriesError.value = "";
+    categories.value = await getCategoryAccuracy(basis.value);
+  } catch (error) {
+    categoriesError.value = toErrorMessage(error, "카테고리 통계를 불러오지 못했습니다.");
+  } finally {
+    categoriesLoading.value = false;
+  }
+}
+
+async function loadQuestions() {
+  try {
+    questionsLoading.value = true;
+    questionsError.value = "";
+    const data = await getQuestionStats({
+      basis: basis.value,
+      page: page.value,
+      size: size.value
+    });
+    questionPage.content = data?.content || [];
+    questionPage.totalPages = Math.max(data?.totalPages || 1, 1);
+    totalPages.value = questionPage.totalPages;
+  } catch (error) {
+    questionsError.value = toErrorMessage(error, "문항 통계를 불러오지 못했습니다.");
+  } finally {
+    questionsLoading.value = false;
+  }
+}
+
+async function loadTopWrong() {
+  try {
+    topWrongLoading.value = true;
+    topWrongError.value = "";
+    topWrongItems.value = await getTopWrongQuestions(limit.value);
+  } catch (error) {
+    topWrongError.value = toErrorMessage(error, "오답 TOP 통계를 불러오지 못했습니다.");
+  } finally {
+    topWrongLoading.value = false;
+  }
+}
+
+async function changePage(nextPage) {
+  page.value = nextPage;
+  await loadQuestions();
+}
+
+async function onSizeChange() {
+  page.value = 1;
+  await loadQuestions();
+}
+
+async function reloadAll() {
+  page.value = 1;
+  await Promise.all([loadCategories(), loadQuestions()]);
+}
+
+onMounted(() => {
+  Promise.all([loadOverview(), loadCategories(), loadQuestions(), loadTopWrong()]);
+});
+</script>

--- a/frontend/src/views/MeStatsView.vue
+++ b/frontend/src/views/MeStatsView.vue
@@ -1,6 +1,113 @@
 <template>
   <section class="card">
     <h2>개인 통계</h2>
-    <p class="muted">마이페이지 통계 상세 화면입니다. API 확장 시 연동합니다.</p>
+
+    <LoadingState v-if="loading" message="개인 통계를 불러오는 중입니다..." />
+
+    <ErrorState
+      v-else-if="errorMessage"
+      :message="errorMessage"
+      :show-retry="true"
+      @retry="loadStats"
+    />
+
+    <EmptyState v-else-if="isEmpty" message="아직 통계 데이터가 없습니다." />
+
+    <div v-else class="stats-grid">
+      <article class="stat-card">
+        <p class="stat-label">총 시도</p>
+        <p class="stat-value">{{ stats.totalAttempts }}</p>
+      </article>
+      <article class="stat-card">
+        <p class="stat-label">완료 시도</p>
+        <p class="stat-value">{{ stats.completedAttempts }}</p>
+      </article>
+      <article class="stat-card">
+        <p class="stat-label">총 제출</p>
+        <p class="stat-value">{{ stats.totalAnswers }}</p>
+      </article>
+      <article class="stat-card">
+        <p class="stat-label">정답 수</p>
+        <p class="stat-value">{{ stats.correctAnswers }}</p>
+      </article>
+      <article class="stat-card">
+        <p class="stat-label">완료율</p>
+        <p class="stat-value">{{ stats.completionRate }}%</p>
+      </article>
+      <article class="stat-card">
+        <p class="stat-label">정답률</p>
+        <p class="stat-value">{{ stats.accuracyRate }}%</p>
+      </article>
+      <article class="stat-card">
+        <p class="stat-label">최근 7일 제출</p>
+        <p class="stat-value">{{ stats.recent7dAnswers }}</p>
+      </article>
+    </div>
   </section>
 </template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from "vue";
+import { getMyStats } from "../api/statsApi";
+import LoadingState from "../components/ui/LoadingState.vue";
+import ErrorState from "../components/ui/ErrorState.vue";
+import EmptyState from "../components/ui/EmptyState.vue";
+
+const stats = reactive({
+  totalAttempts: 0,
+  completedAttempts: 0,
+  totalAnswers: 0,
+  correctAnswers: 0,
+  recent7dAnswers: 0,
+  completionRate: 0,
+  accuracyRate: 0
+});
+
+const loading = ref(false);
+const errorMessage = ref("");
+
+const isEmpty = computed(() => {
+  return (
+    stats.totalAttempts === 0 &&
+    stats.completedAttempts === 0 &&
+    stats.totalAnswers === 0 &&
+    stats.correctAnswers === 0 &&
+    stats.recent7dAnswers === 0
+  );
+});
+
+function toErrorMessage(error) {
+  const status = error?.response?.status;
+  if (status === 400) {
+    return "요청 값이 올바르지 않습니다.";
+  }
+  if (status === 401) {
+    return "로그인이 필요합니다.";
+  }
+  if (status === 403) {
+    return "접근 권한이 없습니다.";
+  }
+  return "개인 통계를 불러오지 못했습니다.";
+}
+
+async function loadStats() {
+  try {
+    loading.value = true;
+    errorMessage.value = "";
+    const data = await getMyStats();
+    stats.totalAttempts = data?.totalAttempts ?? 0;
+    stats.completedAttempts = data?.completedAttempts ?? 0;
+    stats.totalAnswers = data?.totalAnswers ?? 0;
+    stats.correctAnswers = data?.correctAnswers ?? 0;
+    stats.recent7dAnswers = data?.recent7dAnswers ?? 0;
+    stats.completionRate = data?.completionRate ?? 0;
+    stats.accuracyRate = data?.accuracyRate ?? 0;
+  } catch (error) {
+    errorMessage.value = toErrorMessage(error);
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(loadStats);
+</script>

--- a/frontend/src/views/MyPageView.vue
+++ b/frontend/src/views/MyPageView.vue
@@ -21,6 +21,7 @@
       <div class="actions mypage-actions">
         <RouterLink class="btn-link" to="/quiz/wrong-answers">오답노트</RouterLink>
         <RouterLink class="btn-link secondary" to="/quiz/favorites">즐겨찾기</RouterLink>
+        <RouterLink class="btn-link secondary" to="/me/stats">개인 통계</RouterLink>
       </div>
     </section>
 


### PR DESCRIPTION
  ## 작업 내용

  - 사용자/관리자 통계 화면을 실제 Stats API와 연동했습니다.
  - 본 PR 범위에서 학습 랭킹 API는 제외했습니다. (타 이슈/타 담당)

  ## 상세 변경 사항

  - API 연동 추가
      - GET /api/stats/me
      - GET /api/admin/stats/overview
      - GET /api/admin/stats/categories?basis=latest|first
      - GET /api/admin/stats/questions?basis=&page=&size=
      - GET /api/admin/stats/questions/top-wrong?limit=
  - 화면 구현/수정
      - MeStatsView:
          - 개인 통계 카드 표시
          - 로딩/에러/빈 상태 처리
      - AdminStatsView:
          - 개요/카테고리/문항/오답TOP 섹션 구현
          - basis, size, limit 필터 반영
          - 문항 통계 페이지네이션 반영
          - 로딩/에러/빈 상태 처리
      - MyPageView:
          - 개인 통계 이동 버튼 추가
  - 스타일
      - 통계 카드/섹션/필터 레이아웃 스타일 추가

  ## 예외 처리

  - 400: 요청 값 오류 메시지 노출
  - 401: 로그인 필요 메시지 노출
  - 403: 권한 없음 메시지 노출

  ## 제외 범위

  - GET /api/admin/stats/rankings/learning?limit= (학습 랭킹)
      - 타 이슈/타 담당으로 분리

  ## 테스트

  - frontend npm run build 성공
  - 수동 확인
      - /me/stats 정상 조회
      - /admin/stats 개요/카테고리/문항/오답TOP 조회
      - basis/page/size/limit 변경 시 재조회 동작
      - 400/401/403 메시지 노출 확인