### PR TITLE
[Feat] 백엔드 핵심 기능 안정화 패키지 (오답노트/즐겨찾기/신고/통계)

### DIFF
--- a/db/schema_patch_quiz.sql
+++ b/db/schema_patch_quiz.sql
@@ -19,6 +19,23 @@ ALTER TABLE quiz_questions
 ALTER TABLE quiz_questions
   ADD COLUMN IF NOT EXISTS deactivated_at DATETIME NULL AFTER is_active;
 
+-- 1-1-2) quiz_questions: 활성 상태 조회 인덱스
+SET @idx_exists := (
+  SELECT COUNT(1)
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'quiz_questions'
+    AND index_name = 'idx_quiz_questions_active'
+);
+SET @ddl := IF(
+  @idx_exists = 0,
+  'ALTER TABLE quiz_questions ADD INDEX idx_quiz_questions_active (is_active)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 -- 1-2) SENTENCE 문제용 토큰 테이블
 CREATE TABLE IF NOT EXISTS quiz_sentence_tokens (
   token_id BIGINT NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
 ## 작업 내용
  - 오답노트/즐겨찾기/신고/통계 백엔드 핵심 기능을 한 번에 안정화했습니다.
  - DB 스키마-쿼리 불일치로 인한 런타임 오류 가능성을 제거했습니다.
  - 신고 처리 정책(RESOLVED 시 비활성화)과 통계 집계 기준(first/latest)을 정렬했습니다.

  ## 상세 변경 사항
  - DB
  - `quiz_questions`에 `is_active`, `deactivated_at` 반영
  - `idx_quiz_questions_active (is_active)` 인덱스 반영
  - `db/schema.sql`, `db/schema_patch_quiz.sql` 동기화

  - 오답노트/퀴즈
  - 필터 기반 문제 조회 쿼리에 `is_active = 1` 조건 누락 보완
  - 비활성 문제가 퀴즈에 섞이는 케이스 방지

  - 신고(Report)
  - 관리자 상태 변경 시 `RESOLVED`이면 문제 비활성화 연동
  - 설정값 추가:
    - `app.report.auto-deactivate.unique-reporter-threshold`
    - `app.report.auto-deactivate.on-resolved`

  - 통계(Statistics)
  - 오답 TOP API에 `basis(first/latest)` 파라미터 추가
  - 서비스/매퍼/SQL을 기준(first/latest)에 맞게 정렬

  - 테스트
  - `ProblemReportCommandServiceTest` 메서드 불일치 수정
  - `RESOLVED -> deactivate`, `REJECTED -> no deactivate` 테스트 추가

  ## 테스트 방법
  - 실행 환경
  - `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home`

  - 실행 명령
  - `./gradlew test --tests "*ProblemReportCommandServiceTest"`
  - `./gradlew test`

  - 결과
  - `BUILD SUCCESSFUL`

  ## DB 반영 내역
  - 로컬 DB(`jpquiz`)에 `schema_patch_quiz.sql` 적용 완료
  - 검증 결과:
    - `quiz_questions.is_active` 존재 (default=1)
    - `quiz_questions.deactivated_at` 존재
    - `idx_quiz_questions_active` 존재