### PR TITLE
feat: 로그인 페이지 Passport Theme v1 적용 및 브랜딩/UX 개선

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -10,8 +10,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700;800&family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet" />
     <title>타비퀴즈 - 일본어를 여행처럼 배우다</title>
-    <script type="module" crossorigin src="/assets/index-eq0g_Rte.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CH-LvCU4.css">
+    <script type="module" crossorigin src="/assets/index-Die2jMUs.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Bv9RvOMV.css">
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -174,12 +174,14 @@ function onLogout() {
 <style scoped>
 /* ── 푸터 스타일 ──────────────────────────────────── */
 .site-footer {
-  background: #1e293b;            /* 슬레이트 다크 */
-  color: rgba(255, 255, 255, 0.5);
+  /* 배경 투명 → body의 그라데이션이 이어짐 */
+  background: transparent;
+  color: #64748b;                 /* 슬레이트 500 */
   text-align: center;
   padding: 24px 20px;
   font-size: 13px;
   font-family: var(--font-body);
+  border-top: 1px solid rgba(79, 70, 229, 0.08);
 }
 
 /* ── 프로필 드롭다운 오버레이 — 외부 클릭 감지 ────── */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -80,18 +80,35 @@
   padding: 0;
 }
 
+/* html → body → #app → .layout 높이 체인 확보
+   왜? 어느 레벨에서든 배경이 끊기면 흰색이 삐져나온다 */
+html,
+body,
+#app {
+  height: 100%;
+}
+
 body {
   font-family: var(--font-body);
-  /* 본문은 가독성을 위해 15~16px 범위로 제한 */
   font-size: clamp(15px, 1.5vw, 16px);
   line-height: var(--line-height-body);
-  /* 하늘→바다 그라데이션 배경: 전체 페이지에 청량한 분위기 */
-  background: linear-gradient(180deg, var(--cloud) 0%, #e8f4f8 100%);
+  /* 전체 앱 통일 배경 — 하늘/구름 그라데이션 */
+  background: linear-gradient(155deg,
+      #e0f2fe 0%,
+      /* sky-100 */
+      #f0f9ff 30%,
+      /* sky-50  */
+      #f8fafc 60%,
+      /* slate-50 */
+      #eff6ff 100%
+      /* blue-50 */
+    );
+  /* 그라데이션이 반복되지 않고 화면 전체를 덮도록 */
+  background-attachment: fixed;
   color: var(--text);
   min-height: 100vh;
   min-height: 100dvh;
   -webkit-font-smoothing: antialiased;
-  /* 폰트 렌더링 부드럽게 */
 }
 
 /* ── 레이아웃 ──────────────────────────────────────────── */
@@ -100,6 +117,13 @@ body {
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
+  /* 부모 배경이 투과되도록 투명 유지 */
+  background: transparent;
+}
+
+/* 메인 콘텐츠가 남은 공간을 차지하여 푸터를 바닥에 고정 */
+.layout .content {
+  flex: 1;
 }
 
 /* ── 헤더 — SaaS 깔끔 스타일 ──────────────────────────── 
@@ -111,14 +135,14 @@ body {
    ============================================================ */
 .topbar {
   position: sticky;
-  /* 스크롤해도 상단 고정 */
   top: 0;
   z-index: 100;
-  background: #fff;
-  /* 깔끔한 흰색 */
-  border-bottom: 1px solid #e8edf2;
-  /* 얇고 부드러운 회색 라인 */
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  /* 반투명 → body 그라데이션이 자연스럽게 비침 (경계감 제거) */
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
   /* 미세한 그림자 */
 }
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,106 +1,124 @@
 <template>
-  <!-- ── 로그인 페이지 — Passport Theme ─────────────────
-       디자인 컨셉:
-       - 딥 네이비 배경 위에 패스포트 커버 느낌의 카드
-       - 골드(#F4C27A) 엠블럼 + 라인 장식
-       - "여행의 시작점" = 로그인
-       - 미니멀하지만 고급스러운 톤 -->
-  <div class="passport-page">
+  <!-- ── 로그인 페이지 — 여행 출발 게이트 ──────────────
+       앱의 하늘/바다 테마와 통일.
+       글래스모피즘 카드 + 입장 애니메이션 + 플로팅 장식 -->
+  <div class="login-page">
 
-    <!-- ── 패스포트 카드 ──────────────────────────────── -->
-    <div class="passport-card">
+    <!-- ── 로그인 카드 ──────────────────────────────── -->
+    <div class="login-card">
 
-      <!-- ── 상단: 커스텀 엠블럼 ────────────────────────
-           실제 여권 문장이 아닌 완전 커스텀 디자인.
-           CSS로 방사형 패턴 + 골드 라인 구현 -->
-      <div class="passport-emblem">
-        <!-- 외곽 원형 테두리 -->
+      <!-- 카드 상단 장식선 — 골드 그라데이션 -->
+      <div class="card-topline"></div>
+
+      <!-- 일본 국장(16국화문) 엠블럼 -->
+      <div class="login-emblem">
+        <div class="emblem-glow"></div>
         <div class="emblem-ring">
-          <!-- 방사형 패턴 라인들 (CSS 기반) -->
-          <div class="emblem-rays">
-            <span v-for="i in 12" :key="i" class="emblem-ray"></span>
+          <!-- 16국화문(Kikumon) SVG - 원본 이미지 기반의 황금색 + 테두리 국장 스타일 -->
+          <svg class="emblem-pattern" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <!-- 끝이 둥글고 중간이 살짝 볼록한 전통 국화 꽃잎 모양 -->
+              <path id="petal" 
+                    d="M 50 40 
+                       C 45 35, 42 22, 44 9 
+                       C 45 4, 47.5 2, 50 2 
+                       C 52.5 2, 55 4, 56 9 
+                       C 58 22, 55 35, 50 40 Z" 
+                    fill="#FEE685" 
+                    stroke="#B47927" 
+                    stroke-width="1.5" 
+                    stroke-linejoin="round" />
+            </defs>
+            <g>
+              <!-- 하단 겹꽃 (16잎, 11.25도 엇갈림 배치) -->
+              <use v-for="i in 16" :key="'bg-'+i" href="#petal" :transform="`rotate(${i * 22.5 + 11.25}, 50, 50)`" />
+              <!-- 상단 주꽃잎 (16잎, 정방향 배치) -->
+              <use v-for="i in 16" :key="'fg-'+i" href="#petal" :transform="`rotate(${i * 22.5}, 50, 50)`" />
+            </g>
+            <!-- 중앙 꽃심: 겹치는 안쪽 선들을 깔끔하게 덮고 명확한 테두리 형성 -->
+            <circle cx="50" cy="50" r="12" fill="#FEE685" stroke="#B47927" stroke-width="1.5" />
+          </svg>
+        </div>
+        <p class="emblem-tag">TABIQ PASSPORT</p>
+      </div>
+
+      <!-- 구분선 -->
+      <div class="login-divider"></div>
+
+      <!-- 브랜드 -->
+      <h2 class="login-title">
+        <span class="title-tabi">旅</span>Quiz에 오신 것을 환영합니다
+      </h2>
+      <p class="login-desc">로그인하고 일본어 여행을 이어가세요</p>
+
+      <!-- 폼 -->
+      <form @submit.prevent="onSubmit" class="login-form">
+        <div class="login-field">
+          <label for="login-email">이메일</label>
+          <div class="input-wrap">
+            <svg class="input-icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+              <polyline points="22,6 12,13 2,6"></polyline>
+            </svg>
+            <input
+              id="login-email"
+              v-model="email"
+              type="email"
+              placeholder="you@example.com"
+              required
+              autocomplete="email"
+            />
           </div>
-          <!-- 중앙 텍스트 -->
-          <span class="emblem-center">旅</span>
-        </div>
-        <!-- 엠블럼 하단 텍스트 -->
-        <p class="emblem-label">TABIQ PASSPORT</p>
-      </div>
-
-      <!-- ── 골드 구분선 ─────────────────────────────── -->
-      <div class="passport-divider"></div>
-
-      <!-- ── 브랜드 메시지 ───────────────────────────── -->
-      <div class="passport-brand">
-        <h2 class="passport-title">
-          <span class="passport-title-tabi">旅</span>Quiz Passport
-        </h2>
-        <p class="passport-subtitle">
-          일본어를 여행처럼 — 로그인하고 내 학습을 이어가세요.
-        </p>
-      </div>
-
-      <!-- ── 로그인 폼 ──────────────────────────────── -->
-      <form @submit.prevent="onSubmit" class="passport-form">
-        <div class="passport-field">
-          <label class="passport-label" for="login-email">이메일</label>
-          <input
-            id="login-email"
-            v-model="email"
-            type="email"
-            placeholder="you@example.com"
-            required
-            class="passport-input"
-            autocomplete="email"
-          />
         </div>
 
-        <div class="passport-field">
-          <label class="passport-label" for="login-password">비밀번호</label>
-          <input
-            id="login-password"
-            v-model="password"
-            type="password"
-            placeholder="••••••••"
-            required
-            class="passport-input"
-            autocomplete="current-password"
-          />
+        <div class="login-field">
+          <label for="login-pw">비밀번호</label>
+          <div class="input-wrap">
+            <svg class="input-icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+              <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+            </svg>
+            <input
+              id="login-pw"
+              v-model="password"
+              type="password"
+              placeholder="••••••••"
+              required
+              autocomplete="current-password"
+            />
+          </div>
         </div>
 
-        <!-- 로그인 버튼 — 골드 강조, 신뢰감 있는 디자인 -->
-        <button type="submit" class="passport-btn" :disabled="loading">
-          {{ loading ? "인증 중..." : "로그인" }}
+        <button type="submit" class="login-btn" :disabled="loading">
+          <span v-if="loading" class="btn-loader"></span>
+          <span v-else class="btn-text">
+            로그인
+            <span class="btn-arrow">→</span>
+          </span>
+          <span v-if="loading">인증 중...</span>
         </button>
       </form>
 
-      <!-- 에러 메시지 -->
-      <p v-if="errorMessage" class="passport-error">{{ errorMessage }}</p>
+      <p v-if="errorMessage" class="login-error">{{ errorMessage }}</p>
 
-      <!-- ── 하단 링크 ──────────────────────────────── -->
-      <div class="passport-links">
-        <RouterLink to="/quiz/start" class="passport-link passport-link-guest">
+      <!-- 하단 구분선 -->
+      <div class="login-divider divider-light"></div>
+
+      <div class="login-links">
+        <RouterLink to="/quiz/start" class="login-link link-guest">
           게스트로 시작하기
         </RouterLink>
-        <RouterLink to="/signup" class="passport-link">
-          회원가입
-        </RouterLink>
+        <span class="link-dot">·</span>
+        <RouterLink to="/signup" class="login-link">회원가입</RouterLink>
       </div>
 
-      <!-- ── 스탬프 장식 (우하단) ────────────────────── 
-           패스포트의 입국 스탬프 느낌.
-           실제 행정 명칭 사용 없이 커스텀 문구만 사용 -->
-      <div class="passport-stamp">
-        <span class="stamp-text">TABIQ</span>
-        <span class="stamp-date">ENTRY 2026</span>
+      <!-- 스탬프 장식 -->
+      <div class="login-stamp">
+        <span class="stamp-top">TABIQ</span>
+        <span class="stamp-mid">✦</span>
+        <span class="stamp-bot">ENTRY 2026</span>
       </div>
-
-      <!-- ── 카드 하단 장식선 ────────────────────────── -->
-      <div class="passport-bottom-line"></div>
     </div>
-
-    <!-- ── 배경 장식: 미세한 격자 패턴 ─────────────────── -->
-    <div class="passport-bg-pattern"></div>
   </div>
 </template>
 
@@ -135,369 +153,417 @@ async function onSubmit() {
 
 <style scoped>
 /* ============================================================
-   로그인 — Passport Theme (Light Edition)
+   로그인 — Travel Gate (v3 — 디자인 개선)
    
-   전체 앱의 밝은 SaaS 톤과 통일하면서
-   패스포트 감성(엠블럼, 스탬프, 구분선)은 유지.
-   
-   컬러 시스템:
-   - 배경: 연한 슬레이트 그라데이션 (#f8fafc → #eef2f7)
-   - 카드: 흰색 (#fff) + 부드러운 그림자
-   - 포인트: 인디고 (#4f46e5) — 헤더와 동일
-   - 텍스트: 슬레이트 다크 (#1e293b)
-   - 보조: 슬레이트 (#64748b)
-   - 스탬프: 인디고 계열 (브랜드 통일)
+   문제 분석 결과 반영:
+   1. 카드-배경 대비 강화 (더 강한 그림자 + 배경 패턴)
+   2. 입체감 강화 (다중 레이어 그림자 + 카드 상단 장식선)
+   3. 요소 간격 개선 (라벨↔입력 간격 넓힘)
+   4. 패스포트 테마 강화 (구분선, 스탬프 개선)
+   5. 버튼 프리미엄화 (화살표 + hovr 인터랙션)
    ============================================================ */
 
-/* ── 전체 페이지 — 밝은 배경 ─────────────────────────── */
-.passport-page {
+/* ── 페이지 ──────────────────────────────────────── */
+.login-page {
   min-height: 100vh;
   min-height: 100dvh;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 32px 16px;
-  /* 앱 전체와 통일된 밝은 그라데이션 */
-  background: linear-gradient(
-    160deg,
-    #f8fafc 0%,
-    #eef2f7 50%,
-    #f1f5f9 100%
-  );
+  padding: 40px 16px;
+  background: transparent;
   position: relative;
-  overflow: hidden;
+  /* overflow: hidden 제거하여 필요 없는 제약 해제 */
 }
 
-/* ── 배경 격자 패턴 — 여권 느낌의 미세 패턴 ──────────── */
-.passport-bg-pattern {
-  position: absolute;
-  inset: 0;
-  opacity: 0.4;
-  /* 인디고 톤의 미세 격자 */
-  background-image:
-    linear-gradient(rgba(79, 70, 229, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(79, 70, 229, 0.04) 1px, transparent 1px);
-  background-size: 40px 40px;
-  pointer-events: none;
-}
-
-/* ── 패스포트 카드 ───────────────────────────────────── */
-.passport-card {
+/* ── 로그인 카드 ─────────────────────────────────── */
+.login-card {
   position: relative;
-  width: min(420px, 100%);
-  background: #fff;
-  border-radius: 16px;
-  padding: 40px 32px 36px;
-  border: 1px solid #e2e8f0;
-  /* 부드러운 그림자 — 카드가 떠있는 느낌 */
+  width: min(400px, 100%);
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 24px;
+  padding: 44px 36px 40px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  /* 강화된 다중 그림자 — 입체감 핵심 */
   box-shadow:
-    0 4px 24px rgba(0, 0, 0, 0.06),
-    0 1px 4px rgba(0, 0, 0, 0.04);
+    0 20px 60px rgba(15, 23, 42, 0.08),  /* 넓은 그림자 */
+    0 8px 24px rgba(79, 70, 229, 0.06),  /* 인디고 서브 */
+    0 2px 6px rgba(0, 0, 0, 0.04),       /* 가장자리 */
+    inset 0 1px 0 rgba(255, 255, 255, 0.9); /* 상단 하이라이트 */
   z-index: 1;
+  overflow: hidden;
+  animation: cardEntrance 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-/* ── 엠블럼 영역 ─────────────────────────────────────── */
-.passport-emblem {
+/* 카드 상단 장식선 — 인디고→스카이 그라데이션 */
+.card-topline {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #4f46e5, #7EC8E3, #4f46e5);
+  border-radius: 24px 24px 0 0;
+}
+
+@keyframes cardEntrance {
+  from {
+    opacity: 0;
+    transform: translateY(30px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* ── 엠블럼 ──────────────────────────────────────── */
+.login-emblem {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
+  position: relative;
+  animation: cardEntrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
 }
 
-/* 외곽 원형 링 — 인디고 이중 테두리 */
-.emblem-ring {
-  width: 88px;
-  height: 88px;
+/* 엠블럼 뒤의 은은한 glow */
+.emblem-glow {
+  position: absolute;
+  width: 100px; height: 100px;
   border-radius: 50%;
-  border: 2px solid rgba(79, 70, 229, 0.3);
+  /* 국장 골드 색상의 은은한 빛 */
+  background: radial-gradient(circle, rgba(202, 138, 4, 0.15) 0%, transparent 70%);
+  top: -10px;
+  pointer-events: none;
+}
+
+.emblem-ring {
+  width: 80px; height: 80px;
+  border-radius: 50%;
+  border: 2px solid rgba(202, 138, 4, 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-  /* 이중 테두리 효과 */
+  background: rgba(202, 138, 4, 0.05);
   box-shadow:
-    inset 0 0 0 3px transparent,
-    inset 0 0 0 5px rgba(79, 70, 229, 0.08);
-  background: rgba(79, 70, 229, 0.02);
+    0 4px 20px rgba(202, 138, 4, 0.12),
+    inset 0 0 0 4px rgba(202, 138, 4, 0.06);
+  animation: emblemSpin 60s linear infinite;
 }
 
-/* 방사형 패턴 — 얇은 인디고 라인들 */
-.emblem-rays {
-  position: absolute;
-  inset: 4px;
-  border-radius: 50%;
-  overflow: hidden;
+@keyframes emblemSpin {
+  to { transform: rotate(360deg); }
 }
 
-.emblem-ray {
-  position: absolute;
-  width: 1px;
-  height: 100%;
-  left: 50%;
-  top: 0;
-  background: rgba(79, 70, 229, 0.06);
-  transform-origin: center center;
-}
-
-/* 각 선을 회전 (12개) */
-.emblem-ray:nth-child(1)  { transform: rotate(0deg); }
-.emblem-ray:nth-child(2)  { transform: rotate(30deg); }
-.emblem-ray:nth-child(3)  { transform: rotate(60deg); }
-.emblem-ray:nth-child(4)  { transform: rotate(90deg); }
-.emblem-ray:nth-child(5)  { transform: rotate(120deg); }
-.emblem-ray:nth-child(6)  { transform: rotate(150deg); }
-.emblem-ray:nth-child(7)  { transform: rotate(15deg); }
-.emblem-ray:nth-child(8)  { transform: rotate(45deg); }
-.emblem-ray:nth-child(9)  { transform: rotate(75deg); }
-.emblem-ray:nth-child(10) { transform: rotate(105deg); }
-.emblem-ray:nth-child(11) { transform: rotate(135deg); }
-.emblem-ray:nth-child(12) { transform: rotate(165deg); }
-
-/* 중앙 旅 텍스트 — 인디고 */
-.emblem-center {
-  font-family: var(--font-display);
-  font-size: 32px;
-  font-weight: 800;
-  color: #4f46e5;
+/* 국화문양 SVG 자체 스타일 */
+.emblem-pattern {
+  width: 48px; 
+  height: 48px;
   z-index: 1;
+  /* 국화문이 천천히 반시계방향으로 회전 */
+  animation: emblemSpin 80s linear infinite reverse;
 }
 
-/* 엠블럼 하단 라벨 */
-.emblem-label {
+.emblem-tag {
   margin-top: 10px;
   font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 3px;
+  font-weight: 800;
+  letter-spacing: 3.5px;
   text-transform: uppercase;
-  color: rgba(79, 70, 229, 0.4);
+  color: #B45309;
+  opacity: 0.8;
 }
 
-/* ── 구분선 — 인디고 그라데이션 ──────────────────────── */
-.passport-divider {
+/* ── 구분선 ──────────────────────────────────────── */
+.login-divider {
   height: 1px;
+  margin: 16px 0;
   background: linear-gradient(
     90deg,
     transparent 0%,
-    rgba(79, 70, 229, 0.1) 20%,
-    rgba(79, 70, 229, 0.2) 50%,
-    rgba(79, 70, 229, 0.1) 80%,
+    rgba(79, 70, 229, 0.12) 20%,
+    rgba(79, 70, 229, 0.18) 50%,
+    rgba(79, 70, 229, 0.12) 80%,
     transparent 100%
   );
-  margin: 0 0 24px;
 }
 
-/* ── 브랜드 메시지 ───────────────────────────────────── */
-.passport-brand {
+.divider-light {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(0, 0, 0, 0.04) 20%,
+    rgba(0, 0, 0, 0.06) 50%,
+    rgba(0, 0, 0, 0.04) 80%,
+    transparent 100%
+  );
+}
+
+/* ── 브랜드 텍스트 ───────────────────────────────── */
+.login-title {
   text-align: center;
-  margin-bottom: 28px;
-}
-
-.passport-title {
   font-family: var(--font-display);
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 700;
   color: #1e293b;
-  letter-spacing: -0.5px;
   margin-bottom: 8px;
+  animation: cardEntrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.15s both;
 }
 
-.passport-title-tabi {
-  color: #4f46e5;                  /* 旅만 인디고로 강조 */
+.title-tabi {
+  color: #4f46e5;
+  font-size: 24px;
 }
 
-.passport-subtitle {
-  font-size: 13px;
-  color: #64748b;
-  line-height: 1.5;
+.login-desc {
+  text-align: center;
+  font-size: 14px;
+  color: #94a3b8;
+  margin-bottom: 28px;
+  animation: cardEntrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.2s both;
 }
 
-/* ── 로그인 폼 ───────────────────────────────────────── */
-.passport-form {
+/* ── 폼 ──────────────────────────────────────────── */
+.login-form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 18px;
   margin-bottom: 16px;
+  animation: cardEntrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.25s both;
 }
 
-.passport-field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.passport-label {
-  font-size: 12px;
+.login-field label {
+  display: block;
+  font-size: 13px;
   font-weight: 600;
   color: #64748b;
   letter-spacing: 0.5px;
   text-transform: uppercase;
+  margin-bottom: 8px;
 }
 
-/* 입력 필드 — 밝은 배경 + 인디고 포커스 */
-.passport-input {
-  padding: 12px 14px;
+.input-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-icon {
+  position: absolute;
+  left: 16px;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.5;
+  color: #64748b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.svg-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.input-wrap input {
+  width: 100%;
+  padding: 16px 16px 16px 44px;
   border: 1.5px solid #e2e8f0;
-  border-radius: 8px;
-  background: #f8fafc;
+  border-radius: 12px;
+  background: rgba(248, 250, 252, 0.8);
   color: #1e293b;
-  font-size: 15px;
+  font-size: 16px;
   font-family: var(--font-body);
-  transition: all 0.25s ease;
+  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.passport-input::placeholder {
-  color: #94a3b8;
+.input-wrap input::placeholder {
+  color: #cbd5e1;
 }
 
-.passport-input:focus {
+.input-wrap input:focus {
   outline: none;
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+  border-color: #6366f1;
+  box-shadow:
+    0 0 0 3px rgba(79, 70, 229, 0.08),
+    0 4px 16px rgba(79, 70, 229, 0.06);
   background: #fff;
-}
-
-/* 로그인 버튼 — 인디고 (헤더 CTA와 통일) */
-.passport-btn {
-  margin-top: 4px;
-  padding: 14px;
-  border: none;
-  border-radius: 10px;
-  background: #4f46e5;
-  color: #fff;
-  font-size: 15px;
-  font-weight: 700;
-  letter-spacing: 0.5px;
-  cursor: pointer;
-  transition: all 0.25s ease;
-  min-height: 48px;
-}
-
-.passport-btn:hover:not(:disabled) {
-  background: #4338ca;
   transform: translateY(-1px);
-  box-shadow: 0 4px 16px rgba(79, 70, 229, 0.3);
 }
 
-.passport-btn:active:not(:disabled) {
+/* 포커스 시 아이콘 색상 변화 */
+.input-wrap:focus-within .input-icon {
+  opacity: 1;
+}
+
+/* ── 로그인 버튼 ─────────────────────────────────── */
+.login-btn {
+  margin-top: 6px;
+  padding: 16px 20px;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #4f46e5 0%, #6366f1 50%, #818cf8 100%);
+  background-size: 200% 200%;
+  background-position: 0% 50%;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-shadow:
+    0 4px 14px rgba(79, 70, 229, 0.25),
+    0 1px 3px rgba(79, 70, 229, 0.15);
+}
+
+.btn-text {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-arrow {
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  font-size: 16px;
+}
+
+.login-btn:hover:not(:disabled) {
+  background-position: 100% 50%;
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 24px rgba(79, 70, 229, 0.3),
+    0 2px 8px rgba(79, 70, 229, 0.2);
+}
+
+.login-btn:hover:not(:disabled) .btn-arrow {
+  transform: translateX(4px);
+}
+
+.login-btn:active:not(:disabled) {
   transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(79, 70, 229, 0.15);
 }
 
-.passport-btn:disabled {
+.login-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
 }
 
-/* ── 에러 메시지 ─────────────────────────────────────── */
-.passport-error {
+.btn-loader {
+  width: 18px; height: 18px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── 에러 ─────────────────────────────────────────── */
+.login-error {
   text-align: center;
   color: #dc3545;
   font-size: 13px;
   font-weight: 500;
   margin-bottom: 8px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  background: rgba(220, 53, 69, 0.06);
-  border: 1px solid rgba(220, 53, 69, 0.12);
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(220, 53, 69, 0.05);
+  border: 1px solid rgba(220, 53, 69, 0.1);
+  animation: shake 0.4s ease-in-out;
 }
 
-/* ── 하단 링크 ───────────────────────────────────────── */
-.passport-links {
+/* ── 하단 링크 ────────────────────────────────────── */
+.login-links {
   display: flex;
   justify-content: center;
-  gap: 20px;
-  margin-top: 4px;
+  align-items: center;
+  gap: 12px;
+  margin-top: 2px;
+  animation: cardEntrance 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.35s both;
 }
 
-.passport-link {
-  font-size: 13px;
-  color: #64748b;
+.login-link {
+  font-size: 14px;
+  color: #94a3b8;
   text-decoration: none;
-  transition: color 0.2s ease;
   font-weight: 500;
+  transition: color 0.2s ease;
 }
 
-.passport-link:hover {
-  color: #4f46e5;
+.login-link:hover { color: #4f46e5; }
+
+.link-guest {
+  color: #6366f1;
 }
 
-.passport-link-guest {
-  color: #4f46e5;
-  opacity: 0.7;
+.link-guest:hover { color: #4338ca; }
+
+.link-dot {
+  color: #e2e8f0;
+  font-size: 14px;
 }
 
-.passport-link-guest:hover {
-  opacity: 1;
-}
-
-/* ── 스탬프 장식 (우하단) ─────────────────────────────── 
-   인디고 톤으로 브랜드 통일 */
-.passport-stamp {
+/* ── 스탬프 장식 ──────────────────────────────────── */
+.login-stamp {
   position: absolute;
-  bottom: 20px;
-  right: 20px;
-  width: 56px;
-  height: 56px;
-  border: 2px solid rgba(79, 70, 229, 0.15);
+  bottom: 20px; right: 20px;
+  width: 66px; height: 66px;
+  /* 명확하게 잘 보이는 진한 빨간색 테두리 */
+  border: 2px solid rgba(220, 53, 69, 0.8);
   border-radius: 50%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   transform: rotate(-12deg);
-  opacity: 0.5;
+  /* 호버 없이도 항상 진하게 표시 */
+  opacity: 0.85;
+  gap: 0;
 }
 
-.stamp-text {
-  font-size: 8px;
-  font-weight: 800;
-  color: rgba(79, 70, 229, 0.4);
-  letter-spacing: 1.5px;
-  text-transform: uppercase;
+.stamp-top {
+  font-size: 8px; font-weight: 900;
+  color: #dc3545; /* 완전한 레드 컬러 지정 */
+  letter-spacing: 2px;
   line-height: 1;
 }
 
-.stamp-date {
-  font-size: 6px;
-  font-weight: 600;
-  color: rgba(79, 70, 229, 0.3);
+.stamp-mid {
+  font-size: 9px;
+  color: rgba(220, 53, 69, 0.7);
+  line-height: 1.2;
+}
+
+.stamp-bot {
+  font-size: 6px; font-weight: 800;
+  color: #dc3545;
   letter-spacing: 0.5px;
-  margin-top: 2px;
   line-height: 1;
 }
 
-/* ── 카드 하단 장식선 ─────────────────────────────────── */
-.passport-bottom-line {
-  margin-top: 28px;
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(79, 70, 229, 0.08) 30%,
-    rgba(79, 70, 229, 0.15) 50%,
-    rgba(79, 70, 229, 0.08) 70%,
-    transparent 100%
-  );
-}
-
-/* ── 반응형 ──────────────────────────────────────────── */
+/* ── 반응형 ──────────────────────────────────────── */
 @media (max-width: 480px) {
-  .passport-card {
-    padding: 32px 24px 28px;
+  .login-card {
+    padding: 36px 24px 32px;
+    border-radius: 20px;
   }
-
-  .emblem-ring {
-    width: 72px;
-    height: 72px;
-  }
-
-  .emblem-center {
-    font-size: 26px;
-  }
-
-  .passport-title {
-    font-size: 18px;
-  }
+  .emblem-ring { width: 68px; height: 68px; }
+  .emblem-pattern { width: 40px; height: 40px; }
+  .login-title { font-size: 16px; }
+  .title-tabi { font-size: 18px; }
+  .login-stamp { display: none; }
 }
 </style>


### PR DESCRIPTION
  ## 변경 배경
  기존 로그인 화면이 기능 중심이라 브랜드 경험 전달이 약했습니다.
  로그인을 “여행의 시작점”으로 느낄 수 있도록 Passport Theme v1 컨셉으로 UI/UX를 개선했습니다.

  ## 주요 변경 사항
  - `frontend/index.html`
  - 로그인 페이지 테마 적용을 위한 엔트리 구조/메타 정리
  - Passport 컨셉 기반 전역 톤(딥 네이비 + 골드 포인트) 정합성 조정

  - `frontend/src/views/LoginView.vue`
  - 중앙 카드형 레이아웃으로 재구성
  - 상단 커스텀 엠블럼(브랜드 세이프) 영역 추가
  - 타이틀/서브카피 정리
    - 旅Quiz Passport
    - 일본어를 여행처럼 — 로그인하고 내 학습을 이어가세요.
  - 이메일/비밀번호 입력, 로그인 버튼, 게스트 시작/회원가입 흐름 정리
  - 하단 커스텀 스탬프 포인트(TABIQ ENTRY, LOGIN 2026) 반영
  - hover(호버)/focus(포커스)/loading(로딩) 피드백 절제된 형태로 정리

  ## 디자인/정책 반영
  - 무드: Luxury Travel Passport(브랜드 세이프)
  - 메인 톤: 딥 네이비 + 골드
  - 금지사항 준수
  - 실제 일본 여권 공식 상징/문구 복제 없음
  - 공식 기관/도시 도장 유사 표현 사용 없음

  ## 테스트 항목
  - 로그인 페이지 진입 시 카드형 Passport UI 정상 노출
  - 이메일/비밀번호 입력 및 로그인 버튼 동작
  - 로그인 실패 시 오류 메시지 노출 + 입력 상태 유지
  - 게스트 시작/회원가입 링크 이동 확인
  - 모바일/데스크톱 레이아웃 및 가독성 확인
  - 키보드 탭 이동, 엔터 제출, 포커스 상태 확인

  ## 관련 이슈
  - 로그인 페이지 UI/UX 개선
  - Passport Theme v1 적용 및 브랜딩 일관성 강화