### PR TITLE
 [Feat] Passport Theme v1 기반 주요 화면 UI/UX 리디자인 및 출발 게이트 경험 도입

### DIFF
--- a/frontend/src/views/FavoriteListView.vue
+++ b/frontend/src/views/FavoriteListView.vue
@@ -1,52 +1,114 @@
 <template>
-  <section class="card">
-    <h2>즐겨찾기</h2>
+  <div class="passport-container">
+    <!-- 1️⃣ 상단 영역: 여권 컨셉 헤더 -->
+    <header class="passport-header">
+      <div class="header-icon">🛂</div>
+      <h1 class="header-title">나의 여행 도장</h1>
+      <p class="header-subtitle">마음에 든 표현을 모아둔 여권 페이지</p>
+      <div class="gold-divider"></div>
+    </header>
 
-    <LoadingState v-if="loading" message="즐겨찾기를 불러오는 중입니다..." />
+    <main class="passport-content">
+      
+      <!-- 2️⃣ 상단 요약: 여권 스탬프 컬렉션 (시각적 자극) -->
+      <section class="stamps-overview" v-if="!loading && !errorMessage">
+        <div class="overview-header">
+          <h2 class="overview-title">🛂 모은 도장 <strong>{{ totalElements }}</strong>개</h2>
+        </div>
+        
+        <div class="mini-stamps-box" v-if="items.length > 0">
+          <div class="mini-stamps-grid">
+            <div 
+              v-for="(item, index) in items.slice(0, 10)" 
+              :key="'stamp-'+item.questionId"
+              class="mini-stamp"
+              :class="[getRotationClass(index), getCategoryColorClass(item.category)]"
+            >
+              {{ shortenCategory(item.category) }}
+            </div>
+            <div v-if="totalElements > 10" class="mini-stamp-more">+{{ totalElements - 10 }}</div>
+          </div>
+        </div>
+      </section>
 
-    <ErrorState
-      v-else-if="errorMessage"
-      :message="errorMessage"
-      :show-retry="true"
-      @retry="loadItems"
-    />
+      <!-- 기능 버튼 영역 (추후 복습 세트 생성 기능 확장 대비) -->
+      <section class="action-bar" v-if="items.length > 0">
+        <button class="review-btn" @click="startReviewSession" disabled>
+          <span class="btn-icon">✈️</span>
+          <span>이 도장들로 바로 복습하기 (준비중)</span>
+        </button>
+      </section>
 
-    <template v-else>
-      <EmptyState v-if="items.length === 0" message="아직 즐겨찾기한 문제가 없습니다." />
+      <!-- 로딩 및 에러 상태 처리 -->
+      <div v-if="loading" class="state-msg">도장 기록을 펼치는 중입니다...</div>
+      <div v-else-if="errorMessage" class="state-msg error">{{ errorMessage }}</div>
+      
+      <!-- 빈 여권 처리 -->
+      <div v-else-if="items.length === 0" class="empty-state">
+        <div class="empty-icon">📭</div>
+        <p>아직 여권에 찍힌 도장이 없습니다.<br>퀴즈 여행을 떠나 유용한 표현을 스크랩해보세요!</p>
+      </div>
 
+      <!-- 3️⃣ 하단 리스트: 학습용 카드 상세 뷰 (문제 풀이/기능 중심) -->
       <template v-else>
-        <ul class="list-view">
-          <li v-for="item in items" :key="`${item.questionId}-${item.createdAt}`" class="list-item">
-            <p><strong>문제ID:</strong> {{ item.questionId }}</p>
-            <p><strong>문장:</strong> {{ item.questionText }}</p>
-            <p><strong>카테고리:</strong> {{ item.category || "-" }}</p>
-            <p><strong>등록일:</strong> {{ item.createdAt }}</p>
-          </li>
-        </ul>
+        <div class="study-cards-list">
+          <div 
+            v-for="item in items" 
+            :key="item.questionId"
+            class="study-card"
+            :class="{ 'is-deleting': deletingId === item.questionId }"
+          >
+            <!-- 카드 헤더 (카테고리 & 뱃지) -->
+            <div class="card-header">
+              <span class="cat-badge" :class="getCategoryColorClass(item.category).replace('stamp-', 'bg-')">
+                {{ item.category || '기타' }}
+              </span>
+              <span class="date-text">{{ formatDate(item.createdAt) }} 저장</span>
+            </div>
 
-        <div class="actions actions-left pager">
-          <button class="ghost" :disabled="page <= 1" @click="changePage(page - 1)">이전</button>
-          <span>{{ page }} / {{ totalPages }}</span>
-          <button class="ghost" :disabled="page >= totalPages" @click="changePage(page + 1)">다음</button>
+            <!-- 카드 본문 (문제 텍스트 전체 노출) -->
+            <div class="card-body">
+              <p class="question-text">{{ item.questionText }}</p>
+            </div>
+
+            <!-- 카드 하단 (액션 버튼) -->
+            <div class="card-actions">
+              <button class="action-btn primary" @click="solveAgain(item.questionId)" disabled>
+                <span class="icon">🔄</span> 다시 풀기 (준비중)
+              </button>
+              <button class="action-btn danger" @click="removeStamp(item.questionId)">
+                <span class="icon">🧽</span> 도장 지우기
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- 페이지네이션 -->
+        <div class="pager" v-if="totalPages > 1">
+          <button class="pager-btn" :disabled="page <= 1" @click="changePage(page - 1)">이전 페이지</button>
+          <span class="pager-text">{{ page }} / {{ totalPages }}</span>
+          <button class="pager-btn" :disabled="page >= totalPages" @click="changePage(page + 1)">다음 페이지</button>
         </div>
       </template>
-    </template>
-  </section>
+
+    </main>
+  </div>
 </template>
 
 <script setup>
 import { onMounted, ref } from "vue";
-import { getFavorites } from "../api/favoriteApi";
-import LoadingState from "../components/ui/LoadingState.vue";
-import ErrorState from "../components/ui/ErrorState.vue";
-import EmptyState from "../components/ui/EmptyState.vue";
+import { useRouter } from "vue-router";
+import { getFavorites, toggleFavorite } from "../api/favoriteApi";
 
+const router = useRouter();
 const items = ref([]);
 const loading = ref(false);
 const errorMessage = ref("");
 const page = ref(1);
 const size = 10;
 const totalPages = ref(1);
+const totalElements = ref(0);
+const deletingId = ref(null);
 
 async function loadItems() {
   try {
@@ -55,21 +117,9 @@ async function loadItems() {
     const data = await getFavorites(page.value, size);
     items.value = data?.content || [];
     totalPages.value = Math.max(data?.totalPages || 1, 1);
+    totalElements.value = data?.totalElements || items.value.length;
   } catch (error) {
-    const status = error?.response?.status;
-    if (status === 401) {
-      errorMessage.value = "로그인이 필요합니다.";
-      return;
-    }
-    if (status === 403) {
-      errorMessage.value = "접근 권한이 없습니다.";
-      return;
-    }
-    if (status === 500) {
-      errorMessage.value = "서버 오류로 즐겨찾기를 불러오지 못했습니다.";
-      return;
-    }
-    errorMessage.value = "즐겨찾기 조회 중 오류가 발생했습니다.";
+    errorMessage.value = "도장을 불러오지 못했습니다.";
   } finally {
     loading.value = false;
   }
@@ -80,5 +130,319 @@ async function changePage(nextPage) {
   await loadItems();
 }
 
+// 즐겨찾기 해제 (도장 지우기)
+async function removeStamp(questionId) {
+  if (!confirm("이 표현을 도장 목록에서 지우시겠습니까?")) return;
+  
+  try {
+    deletingId.value = questionId; 
+    await toggleFavorite(questionId);
+    
+    // 애니메이션 후 리스트 반영
+    setTimeout(() => {
+      items.value = items.value.filter(item => item.questionId !== questionId);
+      totalElements.value = Math.max(0, totalElements.value - 1);
+      deletingId.value = null;
+      // 목록이 비면 이전 페이지로 돌리기 로직 생략 (단순화)
+    }, 300);
+    
+  } catch (error) {
+    alert("도장을 지우는 데 실패했습니다.");
+    deletingId.value = null;
+  }
+}
+
+function solveAgain(questionId) {
+  // TODO: 단일 문제 풀이 페이지 or scene 기반 퀴즈로 라우팅 연동
+  alert("해당 문제 다시 풀기 모드로 이동합니다. (API 및 라우팅 연결 필요)");
+}
+
+function startReviewSession() {
+  // TODO: 즐겨찾기 전체 리스트를 attempt 생성 API로 말아보내는 로직
+  alert("수집한 도장들을 모아 새로운 여행(복습) 코스를 만듭니다. (API 연결 필요)");
+}
+
+/* ── UI 보조 함수 ──────────────────────────────────── */
+
+function formatDate(dateString) {
+  if (!dateString) return "2026.02";
+  const d = new Date(dateString);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}.${month}.${day}`;
+}
+
+function shortenCategory(category) {
+  if (!category) return "기타";
+  if (category.includes("공항") || category.includes("입국")) return "공항";
+  if (category.includes("교통") || category.includes("이동")) return "교통";
+  if (category.includes("숙박") || category.includes("호텔")) return "숙박";
+  if (category.includes("음식") || category.includes("식당")) return "음식";
+  if (category.includes("쇼핑") || category.includes("상점")) return "쇼핑";
+  if (category.includes("긴급") || category.includes("경찰")) return "긴급";
+  if (category.includes("관광") || category.includes("야간")) return "관광";
+  return category;
+}
+
+function getCategoryColorClass(category) {
+  const shortLine = shortenCategory(category);
+  switch (shortLine) {
+    case "공항": return "stamp-red";
+    case "교통": return "stamp-blue";
+    case "숙박": return "stamp-green";
+    case "음식": return "stamp-orange";
+    case "쇼핑": return "stamp-purple";
+    case "긴급": return "stamp-gray";
+    default: return "stamp-teal";
+  }
+}
+
+function getRotationClass(index) {
+  const rotationClasses = ['rot-1', 'rot-2', 'rot-3', 'rot-4', 'rot-5'];
+  return rotationClasses[index % rotationClasses.length];
+}
+
 onMounted(loadItems);
 </script>
+
+<style scoped>
+/* ── 배경 및 헤더 (여권 테마 유지) ── */
+.passport-container {
+  min-height: 100vh;
+  background-color: #fefce8; 
+  background-image: radial-gradient(rgba(214, 211, 209, 0.2) 1px, transparent 1px);
+  background-size: 20px 20px;
+  padding: 40px 16px 80px;
+  font-family: Pretendard, "Noto Sans KR", serif, sans-serif;
+  color: #1e293b;
+}
+
+.passport-header { text-align: center; margin-bottom: 32px; }
+.header-icon { font-size: 36px; margin-bottom: 8px; }
+.header-title {
+  font-size: 26px; font-weight: 900; color: #0f172a;
+  letter-spacing: 2px; margin: 0 0 8px; font-family: "Noto Serif", serif;
+}
+.header-subtitle { font-size: 14px; font-weight: 600; color: #64748b; margin: 0 0 16px; }
+.gold-divider { width: 80px; height: 3px; background: #eab308; margin: 0 auto; border-radius: 2px; }
+
+.passport-content {
+  max-width: 680px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ── 2️⃣ 상단 요약 (미니 스탬프 컬렉션 표면화) ── */
+.stamps-overview {
+  background: white;
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px dashed #cbd5e1;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.02);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.overview-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #334155;
+  margin: 0 0 20px;
+}
+.overview-title strong {
+  font-size: 22px;
+  color: #0f172a;
+  margin: 0 4px;
+}
+.mini-stamps-box {
+  width: 100%;
+}
+.mini-stamps-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+/* 디자인 핵심: 진짜 미니 도장 느낌 */
+.mini-stamp {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 900;
+  opacity: 0.8;
+  mix-blend-mode: multiply;
+  box-shadow: 0 1px 2px currentColor, inset 0 0 4px rgba(255,255,255,0.5);
+  cursor: default;
+}
+.mini-stamp-more {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #f1f5f9;
+  color: #64748b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+/* 색상 및 회전용 */
+.stamp-red    { color: #ef4444; } 
+.stamp-blue   { color: #3b82f6; } 
+.stamp-green  { color: #22c55e; } 
+.stamp-orange { color: #f97316; } 
+.stamp-purple { color: #a855f7; } 
+.stamp-gray   { color: #475569; } 
+.stamp-teal   { color: #14b8a6; } 
+
+.bg-red    { background: #fee2e2; color: #dc2626; border: 1px solid #fca5a5; } 
+.bg-blue   { background: #dbeafe; color: #2563eb; border: 1px solid #93c5fd; } 
+.bg-green  { background: #dcfce7; color: #16a34a; border: 1px solid #86efac; } 
+.bg-orange { background: #ffedd5; color: #ea580c; border: 1px solid #fdba74; } 
+.bg-purple { background: #f3e8ff; color: #9333ea; border: 1px solid #d8b4fe; } 
+.bg-gray   { background: #f1f5f9; color: #475569; border: 1px solid #cbd5e1; } 
+.bg-teal   { background: #ccfbf1; color: #0d9488; border: 1px solid #5eead4; } 
+
+.rot-1 { transform: rotate(-6deg); }
+.rot-2 { transform: rotate(8deg); }
+.rot-3 { transform: rotate(-2deg); }
+.rot-4 { transform: rotate(5deg); }
+.rot-5 { transform: rotate(-8deg); }
+
+/* ── 기능 버튼 ──────────────────────── */
+.action-bar {
+  display: flex;
+  justify-content: center;
+}
+.review-btn {
+  width: 100%;
+  max-width: 320px;
+  background: #0f172a;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 16px 20px;
+  font-size: 16px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 6px rgba(15, 23, 42, 0.2);
+}
+.review-btn:hover:not(:disabled) { transform: translateY(-2px); box-shadow: 0 8px 12px rgba(15, 23, 42, 0.3); }
+.review-btn:disabled { background: #94a3b8; cursor: not-allowed; box-shadow: none; }
+
+/* ── 3️⃣ 하단 리스트: 실용적 학습 카드 ── */
+.study-cards-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.study-card {
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  border: 1px solid #f1f5f9;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.study-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.08);
+  border-color: #e2e8f0;
+}
+.study-card.is-deleting {
+  opacity: 0;
+  transform: scale(0.95);
+  pointer-events: none;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.cat-badge {
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+.date-text {
+  font-size: 13px;
+  color: #94a3b8;
+  font-family: ui-monospace, sans-serif;
+}
+
+.card-body {
+  margin-bottom: 24px;
+}
+.question-text {
+  font-size: 17px;
+  font-weight: 600;
+  color: #1e293b;
+  line-height: 1.5;
+  margin: 0;
+  word-break: keep-all;
+}
+
+.card-actions {
+  display: flex;
+  gap: 12px;
+  border-top: 1px solid #f1f5f9;
+  padding-top: 16px;
+}
+.action-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.action-btn.primary {
+  background: #f0fdf4;
+  color: #16a34a;
+  border: 1px solid #bbf7d0;
+}
+.action-btn.primary:hover:not(:disabled) { background: #dcfce7; }
+.action-btn.danger {
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #cbd5e1;
+}
+.action-btn.danger:hover { background: #fee2e2; color: #ef4444; border-color: #fca5a5; }
+.action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* 상태 메시지 */
+.state-msg { text-align: center; padding: 40px; color: #64748b; font-weight: 600; }
+.state-msg.error { color: #ef4444; }
+.empty-state { text-align: center; padding: 60px 20px; background: rgba(255,255,255,0.5); border: 2px dashed #e2e8f0; border-radius: 16px; color: #64748b; line-height: 1.6; }
+.empty-icon { font-size: 48px; margin-bottom: 16px; opacity: 0.8; }
+
+/* 페이지네이션 */
+.pager { display: flex; align-items: center; justify-content: center; gap: 16px; margin-top: 40px; }
+.pager-btn { background: transparent; border: 1px solid #cbd5e1; color: #475569; padding: 8px 16px; border-radius: 20px; font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s; }
+.pager-btn:hover:not(:disabled) { background: white; color: #0f172a; border-color: #eab308; }
+.pager-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+.pager-text { font-size: 14px; font-weight: 700; letter-spacing: 2px; color: #334155; font-family: ui-monospace, sans-serif; }
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -141,7 +141,7 @@ async function onSubmit() {
     loading.value = true;
     errorMessage.value = "";
     await authStore.login(email.value, password.value);
-    const redirect = route.query.redirect || "/quiz/start";
+    const redirect = route.query.redirect || "/";
     router.push(String(redirect));
   } catch (error) {
     errorMessage.value = error?.response?.data?.message || "로그인에 실패했습니다.";

--- a/frontend/src/views/MainView.vue
+++ b/frontend/src/views/MainView.vue
@@ -80,11 +80,6 @@
       </h2>
       <p class="section-desc">카테고리를 선택한 뒤, 세부 상황을 골라주세요. 선택하지 않으면 랜덤으로 출제됩니다.</p>
 
-      <!-- ── 대분류 드롭다운 셀렉트 ─────────────────────────
-           왜 드롭다운?
-           - 카테고리가 많아질수록 가로 공간 절약 가능
-           - 모바일에서도 네이티브 select UX 활용
-           - 한눈에 현재 선택 상태를 파악하기 쉬움 -->
       <div class="category-dropdown-wrapper">
         <select
           class="category-dropdown"
@@ -110,40 +105,21 @@
         </span>
       </div>
 
-      <!-- ── 하위 항목 카드 그리드 ───────────────────────── 
-           대분류가 선택되었을 때만 표시
-           기존 scene-card 스타일을 그대로 재사용 -->
-      <div v-if="activeGroupIndex !== null" class="scene-grid">
-        <button
-          class="scene-card"
-          :class="{ selected: selectedSubItem?.groupIdx === activeGroupIndex && selectedSubItem?.itemIdx === iIdx }"
-          v-for="(item, iIdx) in sceneGroups[activeGroupIndex].items"
-          :key="iIdx"
-          @click="toggleSubItem(activeGroupIndex, iIdx)"
-        >
-          <!-- 카드 이미지: 일본풍 일러스트 + 이모지 오버레이 -->
-          <div class="scene-image">
-            <img :src="sceneGroups[activeGroupIndex].image" :alt="item.name" loading="lazy" />
-            <div class="scene-image-overlay"></div>
-            <span class="scene-image-emoji">{{ item.emoji }}</span>
-            <div
-              v-if="selectedSubItem?.groupIdx === activeGroupIndex && selectedSubItem?.itemIdx === iIdx"
-              class="selected-badge"
-            >✓</div>
-          </div>
-          <!-- 카드 정보: 이름 + 상세 설명 -->
-          <div class="scene-info">
-            <strong class="scene-name">{{ item.name }}</strong>
-            <span class="scene-desc" v-if="item.desc">{{ item.desc }}</span>
-          </div>
+      <!-- ── 하위 항목 스위처 (바텀시트 트리거) ───────────────────────── -->
+      <div class="situation-trigger-wrapper">
+        <button class="situation-trigger-btn" @click="openSituationDrawer">
+          <span class="trigger-label">현재 상황</span>
+          <span class="trigger-value" v-if="selectedSubItem !== null">
+            {{ sceneGroups[selectedSubItem.groupIdx].items[selectedSubItem.itemIdx].emoji }}
+            {{ sceneGroups[selectedSubItem.groupIdx].items[selectedSubItem.itemIdx].name }}
+          </span>
+          <span class="trigger-placeholder" v-else>
+            {{ activeGroupIndex !== null ? '상황을 선택해 주세요 (미선택 시 랜덤)' : '카테고리를 먼저 선택해 주세요' }}
+          </span>
+          <span class="trigger-arrow">›</span>
         </button>
       </div>
 
-      <!-- 대분류 미선택 시 안내 메시지 -->
-      <div v-else class="empty-state">
-        <span class="empty-icon">🗾</span>
-        <p class="empty-text">위에서 상황 카테고리를 선택하면<br/>세부 상황이 표시됩니다</p>
-      </div>
     </section>
 
     <!-- ── 4. 시작하기 버튼 (하단 고정형) ───────────────────
@@ -159,12 +135,60 @@
         🌸 퀴즈 시작하기
       </button>
     </section>
+    <!-- ── 5. 상황 선택 바텀시트 (모달/드로어) ─────────────────── -->
+    <transition name="drawer-slide">
+      <div v-if="isSituationOpen" class="drawer-overlay" @click="closeSituationDrawer">
+        <div class="drawer-content" @click.stop>
+          
+          <div class="drawer-header">
+            <h3 class="drawer-title">
+              <span v-if="activeGroupIndex !== null">{{ sceneGroups[activeGroupIndex].icon }} {{ sceneGroups[activeGroupIndex].title }}</span>
+              <span v-else>상황 선택</span>
+            </h3>
+            <button class="drawer-close" @click="closeSituationDrawer">✕</button>
+          </div>
+
+          <div class="drawer-body">
+            <div v-if="activeGroupIndex === null" class="empty-state">
+              <span class="empty-icon">🗾</span>
+              <p class="empty-text">카테고리를 먼저 선택해 주세요</p>
+            </div>
+            
+            <div v-else class="scene-grid">
+              <button
+                class="scene-card"
+                :class="{ selected: selectedSubItem?.groupIdx === activeGroupIndex && selectedSubItem?.itemIdx === iIdx }"
+                v-for="(item, iIdx) in sceneGroups[activeGroupIndex].items"
+                :key="iIdx"
+                @click="selectSubItemAndClose(activeGroupIndex, iIdx)"
+              >
+                <div class="scene-image">
+                  <img :src="sceneGroups[activeGroupIndex].image" :alt="item.name" loading="lazy" />
+                  <div class="scene-image-overlay"></div>
+                  <span class="scene-image-emoji">{{ item.emoji }}</span>
+                  <div
+                    v-if="selectedSubItem?.groupIdx === activeGroupIndex && selectedSubItem?.itemIdx === iIdx"
+                    class="selected-badge"
+                  >✓</div>
+                </div>
+                <div class="scene-info">
+                  <strong class="scene-name">{{ item.name }}</strong>
+                  <span class="scene-desc" v-if="item.desc">{{ item.desc }}</span>
+                </div>
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </transition>
+
   </section>
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
-import { useRouter } from "vue-router";
+import { ref, computed, onMounted, watch } from "vue";
+import { useRouter, useRoute } from "vue-router";
 
 /* ── 카테고리별 이미지 임포트 ─────────────────────────────
    Vite의 import로 빌드 시 해싱된 URL로 자동 변환
@@ -178,9 +202,11 @@ import imgNightlife from "../assets/scenes/business.png";
 import imgEmergency from "../assets/scenes/emergency.png";
 
 const router = useRouter();
+const route = useRoute();
 
 /* ── 상태(State) 관리 ──────────────────────────────────── */
 const categoryType = ref("WORD");
+const isSituationOpen = ref(false); // 바텀시트 열림 여부
 
 /* ── 대분류 + 하위 항목 데이터 구조 ─────────────────────────
    7개 대분류 × 평균 3~5개 하위 항목 = 총 26개 상황
@@ -327,6 +353,43 @@ const activeGroupIndex = ref(null);
 // null이면 미선택 → 전체(랜덤) 모드
 const selectedSubItem = ref(null);
 
+/* ── 딥링크(URL 동기화) 로직 ────────────────────────────── */
+onMounted(() => {
+  const qType = route.query.questionType;
+  const qCategory = route.query.category;
+  const qSituation = route.query.situation;
+  
+  if (qType === 'WORD' || qType === 'SENTENCE') {
+    categoryType.value = qType;
+  }
+  
+  if (qCategory !== undefined) {
+    const gIdx = Number(qCategory);
+    if (gIdx >= 0 && gIdx < sceneGroups.length) {
+      activeGroupIndex.value = gIdx;
+      
+      if (qSituation !== undefined) {
+        const iIdx = Number(qSituation);
+        if (iIdx >= 0 && iIdx < sceneGroups[gIdx].items.length) {
+          selectedSubItem.value = { groupIdx: gIdx, itemIdx: iIdx };
+        }
+      }
+    }
+  }
+});
+
+// 상태 변경 시마다 URL 동기화
+watch([categoryType, activeGroupIndex, selectedSubItem], () => {
+  router.replace({
+    query: {
+      ...route.query,
+      questionType: categoryType.value,
+      category: activeGroupIndex.value ?? undefined,
+      situation: selectedSubItem.value?.itemIdx ?? undefined
+    }
+  }).catch(() => {});
+});
+
 /* ── Computed 속성 ─────────────────────────────────────── */
 
 // selectedSceneId: 선택된 하위 항목의 대분류에 매핑된 DB sceneId
@@ -337,7 +400,12 @@ const selectedSceneId = computed(() => {
 
 // selectedSceneSummary: 하단 요약 영역에 표시할 텍스트
 const selectedSceneSummary = computed(() => {
-  if (selectedSubItem.value === null) return "🗺️ 전체(랜덤)";
+  if (selectedSubItem.value === null) {
+    if (activeGroupIndex.value !== null) {
+      return `${sceneGroups[activeGroupIndex.value].icon} 랜덤 상황`;
+    }
+    return "🗺️ 랜덤 (전체)";
+  }
   const group = sceneGroups[selectedSubItem.value.groupIdx];
   const item = group.items[selectedSubItem.value.itemIdx];
   return `${group.icon} ${item.name}`;
@@ -346,33 +414,45 @@ const selectedSceneSummary = computed(() => {
 /* ── 이벤트 핸들러 ─────────────────────────────────────── */
 
 // onGroupChange: 드롭다운에서 대분류 선택 시 호출
-// event.target.value가 문자열이므로 Number()로 변환
 function onGroupChange(event) {
   const val = event.target.value;
   if (val === "") {
-    // 빈 값 선택 → 전체 모드
     activeGroupIndex.value = null;
     selectedSubItem.value = null;
   } else {
     activeGroupIndex.value = Number(val);
-    // 대분류 변경 시 이전 하위 선택 해제
     selectedSubItem.value = null;
+    // 대분류를 선택하면 자동으로 드로어를 열어서 하위상황을 고를 수 있게 유도
+    isSituationOpen.value = true;
   }
 }
 
-// toggleSubItem: 하위 항목 카드 클릭 시 선택/해제 토글
-function toggleSubItem(gIdx, iIdx) {
+// 바텀시트 제어
+function openSituationDrawer() {
+  if (activeGroupIndex.value === null) {
+    alert("카테고리를 먼저 선택해 주세요.");
+    return;
+  }
+  isSituationOpen.value = true;
+}
+
+function closeSituationDrawer() {
+  isSituationOpen.value = false;
+}
+
+// 하위 항목 카드 클릭 시 선택하고 모달 닫기
+function selectSubItemAndClose(gIdx, iIdx) {
   if (
     selectedSubItem.value &&
     selectedSubItem.value.groupIdx === gIdx &&
     selectedSubItem.value.itemIdx === iIdx
   ) {
-    // 같은 카드 재클릭 → 선택 해제
+    // 같은 카드 재클릭 시 선택 해제
     selectedSubItem.value = null;
   } else {
-    // 새로운 카드 선택
     selectedSubItem.value = { groupIdx: gIdx, itemIdx: iIdx };
   }
+  closeSituationDrawer();
 }
 
 // onStart: 현재 설정으로 퀴즈 시작
@@ -979,10 +1059,131 @@ function onStartTravel() {
   }
 }
 
-/* 아주 작은 화면: 카드 1열 */
-@media (max-width: 479px) {
-  .scene-grid {
-    grid-template-columns: 1fr;
-  }
+/* ── 하위 항목 스위처 (트리거 버튼) ───────────────────── */
+.situation-trigger-wrapper {
+  margin-top: 12px;
 }
+.situation-trigger-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #ffffff;
+  border: 2px solid rgba(126, 200, 227, 0.25);
+  border-radius: var(--radius-md);
+  padding: 16px 20px;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
+}
+.situation-trigger-btn:hover {
+  border-color: var(--sky);
+  box-shadow: 0 10px 15px -3px rgba(58, 134, 184, 0.1);
+  transform: translateY(-2px);
+}
+.trigger-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-muted);
+  margin-right: auto;
+}
+.trigger-value {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--dark);
+  margin-right: 12px;
+}
+.trigger-placeholder {
+  font-size: 15px;
+  font-weight: 500;
+  color: #94a3b8;
+  margin-right: 12px;
+}
+.trigger-arrow {
+  font-size: 20px;
+  color: var(--text-muted);
+}
+
+
+/* ── 바텀시트 (모달/드로어) ──────────────────────────── */
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 9999;
+  display: flex;
+  align-items: flex-end; /* 아래쪽에 붙앰 */
+}
+
+.drawer-content {
+  background: #f8fafc;
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  border-radius: 24px 24px 0 0;
+  padding: 24px 20px 48px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 -10px 40px rgba(0,0,0,0.2);
+}
+
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(0,0,0,0.05);
+}
+.drawer-title {
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--dark);
+  margin: 0;
+}
+.drawer-close {
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+}
+.drawer-close:hover {
+  color: var(--dark);
+}
+
+.drawer-body {
+  overflow-y: auto;
+  /* 스크롤바 커스텀 */
+  padding-right: 4px;
+}
+.drawer-body::-webkit-scrollbar {
+  width: 6px;
+}
+.drawer-body::-webkit-scrollbar-track {
+  background: transparent; 
+}
+.drawer-body::-webkit-scrollbar-thumb {
+  background: rgba(126, 200, 227, 0.5); 
+  border-radius: 4px;
+}
+
+/* 드로어 트랜지션 효과 */
+.drawer-slide-enter-active,
+.drawer-slide-leave-active {
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.drawer-slide-enter-from,
+.drawer-slide-leave-to {
+  opacity: 0;
+}
+.drawer-slide-enter-from .drawer-content,
+.drawer-slide-leave-to .drawer-content {
+  transform: translateY(100%);
+}
+
 </style>

--- a/frontend/src/views/MyPageView.vue
+++ b/frontend/src/views/MyPageView.vue
@@ -1,43 +1,169 @@
 <template>
-  <section class="card">
-    <h2>마이페이지</h2>
+  <div class="mypage-container">
+    <!-- 4️⃣ 상단 영역: 나의 여행 기록 -->
+    <header class="mypage-header">
+      <div class="header-icon">🧭</div>
+      <h1 class="header-title">나의 여행 기록</h1>
+      <p class="header-subtitle">“일본어를 여행처럼 배우다”</p>
+      <div class="gold-divider"></div>
+    </header>
 
-    <section class="mypage-panel">
-      <h3>회원 정보</h3>
-      <p v-if="profileLoading" class="muted">회원 정보를 불러오는 중입니다...</p>
-      <p v-else-if="profileErrorMessage" class="error">{{ profileErrorMessage }}</p>
-      <form v-else class="form" @submit.prevent="saveProfile">
-        <input :value="profile.email" type="email" disabled />
-        <input v-model="nickname" type="text" placeholder="닉네임" />
-        <button type="submit" :disabled="savingProfile">
-          {{ savingProfile ? "저장 중..." : "닉네임 저장" }}
-        </button>
-      </form>
-      <p v-if="profileSuccessMessage" class="muted">{{ profileSuccessMessage }}</p>
-    </section>
+    <main class="mypage-content">
+      
+      <!-- 1️⃣ 🎫 여행자 프로필 카드 (Passport 컨셉) -->
+      <section class="passport-section">
+        <div class="passport-card">
+          <!-- 배경 일본 도장 워터마크 -->
+          <div class="passport-watermark">入国許可<br>旅Quiz</div>
 
-    <section class="mypage-panel">
-      <h3>학습 바로가기</h3>
-      <div class="actions mypage-actions">
-        <RouterLink class="btn-link" to="/quiz/wrong-answers">오답노트</RouterLink>
-        <RouterLink class="btn-link secondary" to="/quiz/favorites">즐겨찾기</RouterLink>
-        <RouterLink class="btn-link secondary" to="/me/stats">개인 통계</RouterLink>
-      </div>
-    </section>
+          <div class="passport-header">
+            <span class="passport-flag">🇯🇵</span>
+            <span class="passport-title">TRAVELER PASSPORT</span>
+          </div>
 
-    <section class="mypage-panel">
-      <h3>학습 통계</h3>
-      <p v-if="statsLoading" class="muted">통계를 불러오는 중입니다...</p>
-      <p v-else-if="statsErrorMessage" class="error">{{ statsErrorMessage }}</p>
-      <ul v-else class="stats-list">
-        <li>총 시도 수: {{ stats.totalAttempts }}</li>
-        <li>완료 시도 수: {{ stats.completedAttempts }}</li>
-        <li>총 제출 수: {{ stats.totalAnswers }}</li>
-        <li>정답 수: {{ stats.correctAnswers }}</li>
-        <li>정답률: {{ stats.accuracyRate }}%</li>
-      </ul>
-    </section>
-  </section>
+          <div class="passport-body">
+            <div class="info-group">
+              <span class="info-label">여권 이름 (닉네임)</span>
+              <div class="info-input-row" v-if="!profileLoading && !profileErrorMessage">
+                <input 
+                  type="text" 
+                  v-model="nickname" 
+                  class="passport-input" 
+                  placeholder="예: 타비타로"
+                  @keyup.enter="saveProfile"
+                />
+                <button class="save-btn" @click="saveProfile" :disabled="savingProfile">
+                  {{ savingProfile ? "갱신 중" : "수정" }}
+                </button>
+              </div>
+              <div v-else class="info-value loading-text">불러오는 중...</div>
+            </div>
+
+            <div class="info-group">
+              <span class="info-label">이메일 (연락처)</span>
+              <span class="info-value">{{ profile.email || '불러오는 중...' }}</span>
+            </div>
+
+            <div class="info-group">
+              <span class="info-label">여행 시작일</span>
+              <span class="info-value date-value">2026.02.22</span>
+            </div>
+          </div>
+          
+          <div v-if="profileErrorMessage" class="msg error-msg">⚠ {{ profileErrorMessage }}</div>
+          <div v-if="profileSuccessMessage" class="msg success-msg">✓ {{ profileSuccessMessage }}</div>
+        </div>
+      </section>
+
+      <!-- 2️⃣ 🗺️ 나의 일본 여행 기록 (통계 4분할 그리드) -->
+      <section class="record-section">
+        <h2 class="section-title">🗺️ 나의 일본 여행 기록</h2>
+        
+        <div v-if="statsLoading" class="loading-state">기록을 조회하고 있습니다...</div>
+        <div v-else-if="statsErrorMessage" class="msg error-msg">⚠ {{ statsErrorMessage }}</div>
+        
+        <div v-else class="stats-grid">
+          <div class="stat-card">
+            <div class="stat-icon">✈️</div>
+            <div class="stat-data">{{ stats.totalAttempts }}<span class="stat-unit">회</span></div>
+            <div class="stat-label">방문한 여행 횟수</div>
+          </div>
+          
+          <div class="stat-card">
+            <div class="stat-icon">🏁</div>
+            <div class="stat-data">{{ stats.completedAttempts }}<span class="stat-unit">회</span></div>
+            <div class="stat-label">완주한 여행</div>
+          </div>
+          
+          <div class="stat-card">
+            <div class="stat-icon">🎯</div>
+            <div class="stat-data">{{ stats.correctAnswers }}<span class="stat-unit">개</span></div>
+            <div class="stat-label">성공한 미션</div>
+          </div>
+          
+          <div class="stat-card">
+            <div class="stat-icon">📊</div>
+            <div class="stat-data">{{ stats.accuracyRate }}<span class="stat-unit">%</span></div>
+            <div class="stat-label">여행 성공률</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ✨ 미친 디테일: Scene별 여행 지도 진행도 (UI 퍼블리싱) -->
+      <section class="map-progress-section">
+        <h2 class="section-title">🗾 여행 노선 달성도</h2>
+        <div class="progress-list">
+          <!-- 공항 -->
+          <div class="progress-item completed">
+            <div class="p-header">
+              <span class="p-icon">✈️</span>
+              <span class="p-name">공항 / 입국</span>
+              <span class="p-status">✅</span>
+            </div>
+            <div class="p-bar-bg"><div class="p-bar-fill" style="width: 100%;"></div></div>
+            <div class="p-text">100% 클리어</div>
+          </div>
+          <!-- 교통 -->
+          <div class="progress-item in-progress">
+            <div class="p-header">
+              <span class="p-icon">🚉</span>
+              <span class="p-name">교통 / 이동</span>
+              <span class="p-status">🔄</span>
+            </div>
+            <div class="p-bar-bg"><div class="p-bar-fill" style="width: 65%;"></div></div>
+            <div class="p-text">65% 진행 중</div>
+          </div>
+          <!-- 숙박 -->
+          <div class="progress-item not-started">
+            <div class="p-header">
+              <span class="p-icon">🏨</span>
+              <span class="p-name">숙박 / 호텔</span>
+              <span class="p-status">❌</span>
+            </div>
+            <div class="p-bar-bg"><div class="p-bar-fill" style="width: 0%;"></div></div>
+            <div class="p-text">미방문</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3️⃣ 🧳 오답노트 / 즐겨찾기 / 개인 통계 (여행 가방 메뉴) -->
+      <section class="baggage-section">
+        <h2 class="section-title">🧳 나의 여행 가방</h2>
+        <div class="menu-list">
+          <RouterLink to="/quiz/wrong-answers" class="menu-card">
+            <div class="menu-left">
+              <div class="menu-icon-wrap">📓</div>
+              <span class="menu-text">오답노트</span>
+            </div>
+            <div class="menu-right">
+              <span class="menu-arrow">→</span>
+            </div>
+          </RouterLink>
+          
+          <RouterLink to="/quiz/favorites" class="menu-card">
+            <div class="menu-left">
+              <div class="menu-icon-wrap">⭐</div>
+              <span class="menu-text">즐겨찾기</span>
+            </div>
+            <div class="menu-right">
+              <span class="menu-arrow">→</span>
+            </div>
+          </RouterLink>
+          
+          <RouterLink to="/me/stats" class="menu-card">
+            <div class="menu-left">
+              <div class="menu-icon-wrap">📊</div>
+              <span class="menu-text">개인 상세 통계</span>
+            </div>
+            <div class="menu-right">
+              <span class="menu-arrow">→</span>
+            </div>
+          </RouterLink>
+        </div>
+      </section>
+
+    </main>
+  </div>
 </template>
 
 <script setup>
@@ -69,18 +195,10 @@ const statsErrorMessage = ref("");
 
 function toErrorMessage(error, defaultMessage) {
   const status = error?.response?.status;
-  if (status === 401) {
-    return "로그인이 필요합니다.";
-  }
-  if (status === 403) {
-    return "접근 권한이 없습니다.";
-  }
-  if (status === 404) {
-    return "데이터를 찾을 수 없습니다.";
-  }
-  if (status === 400) {
-    return error?.response?.data?.message || "요청 값이 올바르지 않습니다.";
-  }
+  if (status === 401) return "로그인이 필요합니다.";
+  if (status === 403) return "접근 권한이 없습니다.";
+  if (status === 404) return "데이터를 찾을 수 없습니다.";
+  if (status === 400) return error?.response?.data?.message || "요청 값이 올바르지 않습니다.";
   return defaultMessage;
 }
 
@@ -104,23 +222,22 @@ async function saveProfile() {
     profileErrorMessage.value = "닉네임을 입력해 주세요.";
     return;
   }
-
   try {
     savingProfile.value = true;
     profileErrorMessage.value = "";
     profileSuccessMessage.value = "";
-
     await updateMyProfile({ nickname: nickname.value.trim() });
     profile.nickname = nickname.value.trim();
-    profileSuccessMessage.value = "닉네임이 수정되었습니다.";
+    profileSuccessMessage.value = "여권 이름이 성공적으로 갱신되었습니다.";
+    setTimeout(() => { profileSuccessMessage.value = ""; }, 3000);
   } catch (error) {
     const status = error?.response?.status;
     const code = error?.response?.data?.code;
     if (status === 409 && code === "DUPLICATE_NICKNAME") {
-      profileErrorMessage.value = "이미 사용 중인 닉네임입니다.";
+      profileErrorMessage.value = "이미 다른 여행자가 사용 중인 이름입니다.";
       return;
     }
-    profileErrorMessage.value = toErrorMessage(error, "회원 정보 수정 중 오류가 발생했습니다.");
+    profileErrorMessage.value = toErrorMessage(error, "정보 갱신 중 오류가 발생했습니다.");
   } finally {
     savingProfile.value = false;
   }
@@ -137,7 +254,7 @@ async function loadStats() {
     stats.correctAnswers = data?.correctAnswers ?? 0;
     stats.accuracyRate = data?.accuracyRate ?? 0;
   } catch (error) {
-    statsErrorMessage.value = toErrorMessage(error, "통계를 불러오지 못했습니다.");
+    statsErrorMessage.value = toErrorMessage(error, "여행 기록을 불러오지 못했습니다.");
   } finally {
     statsLoading.value = false;
   }
@@ -147,3 +264,370 @@ onMounted(async () => {
   await Promise.all([loadProfile(), loadStats()]);
 });
 </script>
+
+<style scoped>
+/* ── 배경 및 전체 레이아웃 (오프화이트 & 골드네이비 톤) ── */
+.mypage-container {
+  min-height: 100vh;
+  /* 아주 연한 베이지에 미세한 도트 패턴을 넣어 종이 질감 연출 */
+  background-color: #fdfbf7;
+  background-image: radial-gradient(#e2e8f0 1px, transparent 1px);
+  background-size: 20px 20px;
+  padding: 40px 16px 80px;
+  font-family: Pretendard, "Noto Sans KR", serif, sans-serif;
+  color: #1e293b;
+}
+
+/* 4️⃣ 상단 영역: 나의 여행 기록 */
+.mypage-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+.header-icon {
+  font-size: 36px;
+  margin-bottom: 8px;
+  animation: float 3s ease-in-out infinite;
+}
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+.header-title {
+  font-size: 26px;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: 1px;
+  margin: 0 0 8px;
+  font-family: "Noto Serif", serif;
+}
+.header-subtitle {
+  font-size: 15px;
+  font-weight: 600;
+  color: #64748b;
+  margin: 0 0 16px;
+}
+.gold-divider {
+  width: 60px;
+  height: 3px;
+  background: #eab308; /* yellow-500 */
+  margin: 0 auto;
+  border-radius: 2px;
+}
+
+.mypage-content {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+.section-title {
+  font-size: 19px;
+  font-weight: 800;
+  color: #0f172a;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* 1️⃣ 여행자 프로필 카드 (Passport 컨셉) */
+.passport-card {
+  position: relative;
+  background: #0f172a; /* navy-900 */
+  border: 2px solid #eab308; /* yellow-500 */
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.2), 0 8px 10px -6px rgba(15, 23, 42, 0.1);
+  overflow: hidden;
+  color: #f8fafc;
+  /* 부드러운 블러 효과 */
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+.passport-watermark {
+  position: absolute;
+  top: 15%;
+  right: -5%;
+  font-size: 40px;
+  font-weight: 900;
+  color: rgba(234, 179, 8, 0.08); /* 금색 도장 워터마크 */
+  transform: rotate(-15deg);
+  pointer-events: none;
+  font-family: "Noto Serif JP", serif;
+  border: 3px double rgba(234, 179, 8, 0.08);
+  border-radius: 50%;
+  width: 140px;
+  height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  line-height: 1.2;
+}
+.passport-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 28px;
+  border-bottom: 1px solid rgba(234, 179, 8, 0.3);
+  padding-bottom: 16px;
+}
+.passport-flag {
+  font-size: 26px;
+}
+.passport-title {
+  font-size: 18px;
+  font-weight: 800;
+  color: #eab308;
+  letter-spacing: 2px;
+  font-family: ui-monospace, sans-serif;
+}
+
+.passport-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+  z-index: 2;
+}
+.info-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.info-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #94a3b8;
+  letter-spacing: 1px;
+}
+.info-value {
+  font-size: 17px;
+  font-weight: 700;
+  color: #f1f5f9;
+}
+.date-value {
+  color: #cbd5e1;
+  font-family: ui-monospace, monospace;
+}
+.info-input-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.passport-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid #475569;
+  color: #f8fafc;
+  font-size: 18px;
+  font-weight: 700;
+  padding: 8px 4px 4px;
+  outline: none;
+  transition: border-color 0.2s;
+  font-family: inherit;
+}
+.passport-input:focus {
+  border-bottom-color: #eab308;
+}
+.passport-input::placeholder {
+  color: #475569;
+  font-weight: 500;
+}
+.save-btn {
+  background: #eab308;
+  color: #0f172a;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.save-btn:hover:not(:disabled) { background: #fde047; transform: translateY(-1px); }
+.save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.msg {
+  font-size: 13px;
+  font-weight: 600;
+  margin-top: 20px;
+  padding: 12px;
+  border-radius: 6px;
+  text-align: center;
+}
+.error-msg { background: rgba(248, 113, 113, 0.1); color: #fca5a5; }
+.success-msg { background: rgba(74, 222, 128, 0.1); color: #86efac; }
+
+
+/* 2️⃣ 🗺️ 나의 일본 여행 기록 (통계 그리드) */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+@media (min-width: 600px) {
+  .stats-grid { grid-template-columns: repeat(4, 1fr); }
+}
+.stat-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px 16px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+  text-align: center;
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s;
+  border: 1px solid #f1f5f9;
+}
+.stat-card:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  border-color: #e2e8f0;
+}
+.stat-icon {
+  font-size: 32px;
+  margin-bottom: 12px;
+}
+.stat-data {
+  font-size: 24px;
+  font-weight: 900;
+  color: #0f172a;
+  margin-bottom: 4px;
+}
+.stat-unit {
+  font-size: 14px;
+  font-weight: 600;
+  color: #64748b;
+  margin-left: 2px;
+}
+.stat-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: #94a3b8;
+}
+
+
+/* ✨ 미친 디테일: 여행 노선 달성도 progress UI */
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.progress-item {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 20px;
+  border: 1px solid #f1f5f9;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.02);
+}
+.p-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.p-icon { font-size: 20px; }
+.p-name { font-size: 15px; font-weight: 700; color: #1e293b; flex: 1; }
+.p-status { font-size: 16px; }
+
+.p-bar-bg {
+  height: 8px;
+  background: #f1f5f9;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+.p-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 1s ease-out;
+}
+/* 상태별 프로그레스바 컬러 */
+.completed .p-bar-fill { background: #10b981; } /* 초록 */
+.completed .p-text { color: #10b981; }
+.in-progress .p-bar-fill { background: #3b82f6; } /* 파랑 */
+.in-progress .p-text { color: #3b82f6; }
+.not-started .p-bar-fill { background: #cbd5e1; } /* 회색 */
+.not-started .p-text { color: #94a3b8; }
+
+.p-text {
+  font-size: 12px;
+  font-weight: 700;
+  text-align: right;
+}
+
+
+/* 3️⃣ 🧳 가방 메뉴 리스트 */
+.menu-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.menu-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  text-decoration: none;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+  border: 1px solid #f1f5f9;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.menu-card:hover {
+  transform: translateY(-4px) scale(1.01);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08);
+  background: #f8fafc; /* 연한 블루그레이 빛 */
+  border-color: #e2e8f0;
+}
+.menu-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.menu-icon-wrap {
+  width: 48px;
+  height: 48px;
+  background: #f1f5f9;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  transition: background 0.2s;
+}
+.menu-card:hover .menu-icon-wrap {
+  background: #e2e8f0;
+}
+.menu-text {
+  font-size: 17px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+/* 화살표 애니메이션 등장 */
+.menu-arrow {
+  color: #94a3b8;
+  font-size: 24px;
+  font-weight: bold;
+  opacity: 0;
+  transform: translateX(-15px);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.menu-card:hover .menu-arrow {
+  opacity: 1;
+  transform: translateX(0);
+  color: #3b82f6; /* 파란색 화살표 포인트 */
+}
+
+/* 로딩 상태 */
+.loading-state {
+  text-align: center;
+  padding: 40px;
+  color: #64748b;
+  font-weight: 600;
+  font-size: 15px;
+}
+</style>

--- a/frontend/src/views/QuizStartView.vue
+++ b/frontend/src/views/QuizStartView.vue
@@ -1,14 +1,80 @@
 <template>
-  <section class="card">
-    <h2>퀴즈 시작</h2>
-    <p>문제 수는 10문제로 고정됩니다.</p>
-    <button @click="start" :disabled="loading">{{ loading ? "시작 중..." : "퀴즈 시작" }}</button>
-    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
-  </section>
+  <div class="boarding-page" :class="{ 'is-departing': isDeparting }">
+
+    <!-- 페이지 단독 풀스크린 느낌을 위한 헤더 (상단 내비게이션을 덮는 느낌 연출) -->
+    <div class="airport-header">
+      <!-- 로고 제거 요청 -->
+      <div></div>
+      <button class="back-btn" @click="router.back()">← 돌아가기</button>
+    </div>
+
+    <!-- 비행기 이륙 애니메이션 오버레이 -->
+    <div v-if="isDeparting" class="takeoff-overlay">
+      <div class="airplane">✈︎</div>
+      <div class="clouds-fx">☁ ☁ ☁</div>
+    </div>
+
+    <div class="ticket-card">
+      <div class="ticket-top">
+        <h1 class="gate-title">BOARDING GATE</h1>
+        <div class="gate-subtitle">타비퀴즈 출발 게이트</div>
+      </div>
+
+      <div class="ticket-middle">
+        <!-- 10이라는 숫자 극대화 -->
+        <div class="question-count-block">
+          <span class="q-num">10</span>
+          <span class="q-text">QUESTIONS</span>
+        </div>
+
+        <div class="dotted-line"></div>
+
+        <!-- 3️⃣ 테이블이 아닌 카드식 정보 구조 -->
+        <div class="flight-info-grid">
+          <div class="info-item full-width">
+            <span class="i-label">모드</span>
+            <span class="i-value">{{ modeLabel }}</span>
+          </div>
+          <div class="info-item full-width">
+            <span class="i-label">상황</span>
+            <span class="i-value">{{ sceneLabel }}</span>
+          </div>
+          <div class="info-item full-width">
+            <span class="i-label">예상 소요 시간</span>
+            <span class="i-value time-val">약 3~5분</span>
+          </div>
+        </div>
+
+        <div class="dotted-line"></div>
+
+        <!-- 4️⃣ 오늘의 미션 박스화 -->
+        <div class="mission-box">
+          <div class="m-badge">오늘의 미션 미리보기</div>
+          <div class="m-text">“{{ randomMission }}”</div>
+        </div>
+
+        <div v-if="errorMessage" class="error-msg">
+          ⚠ {{ errorMessage }}
+        </div>
+      </div>
+
+      <!-- 5️⃣ 가장 강렬한 하단 분리형 CTA 영역 -->
+      <div class="ticket-bottom">
+        <button class="depart-btn" @click="startBoarding" :disabled="loading || isDeparting">
+          <span v-if="loading" class="btn-loader"></span>
+          <span v-else class="btn-text-group">
+            <span class="btn-main">✈ 탑승 시작하기</span>
+            <span class="btn-sub">START BOARDING</span>
+          </span>
+        </button>
+        <div class="footer-wish">안전하고 즐거운 여행 되세요.</div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { startQuiz } from "../api/quizApi";
 import { useQuizStore } from "../stores/quizStore";
@@ -16,69 +82,414 @@ import { useQuizStore } from "../stores/quizStore";
 const router = useRouter();
 const route = useRoute();
 const quizStore = useQuizStore();
+
 const loading = ref(false);
 const errorMessage = ref("");
+const isDeparting = ref(false);
 
 const selectedQuestionType = computed(() => {
   const value = String(route.query.questionType || "").toUpperCase();
-  if (value === "WORD" || value === "SENTENCE") {
-    return value;
-  }
+  if (value === "WORD" || value === "SENTENCE") return value;
   return null;
 });
 
 const selectedSceneId = computed(() => {
   const raw = route.query.sceneId;
-  if (raw == null || raw === "") {
-    return null;
-  }
+  if (!raw) return null;
   const parsed = Number(raw);
-  if (Number.isNaN(parsed) || parsed <= 0) {
-    return null;
-  }
-  return parsed;
+  return Number.isNaN(parsed) || parsed <= 0 ? null : parsed;
 });
 
-async function start() {
+const modeLabel = computed(() => {
+  return selectedQuestionType.value === "WORD" ? "📝 단어" :
+         selectedQuestionType.value === "SENTENCE" ? "💬 문장" : "단어";
+});
+
+const sceneMap = {
+  1: "✈️ 공항 / 입출국",
+  2: "🚉 교통 / 이동",
+  3: "🏨 숙박",
+  4: "🍣 음식 / 술",
+  5: "🏪 쇼핑 / 상점",
+  6: "🌙 야간 / 즐길거리",
+  7: "🚨 긴급 상황",
+  8: "🏛️ 관광지 / 명소"
+};
+
+const sceneLabel = computed(() => {
+  if (selectedSceneId.value && sceneMap[selectedSceneId.value]) {
+    return sceneMap[selectedSceneId.value];
+  }
+  return "🗺️ 전체 (랜덤 출제)";
+});
+
+const missions = [
+  "수하물을 맡기고 싶습니다.",
+  "이 근처에 역이 있나요?",
+  "체크인 부탁드립니다.",
+  "메뉴판 좀 주시겠어요?",
+  "이거 얼마인가요?",
+  "사진 좀 찍어주시겠어요?",
+  "따뜻한 커피 한 잔 주세요.",
+  "오늘의 추천 메뉴는 뭔가요?",
+  "여기서 유명한 곳이 어딘가요?"
+];
+const randomMission = ref("");
+
+onMounted(() => {
+  // 실제 앱 레이아웃(헤더 등)을 덮어버리기 위한 임시 꼼수 (CSS fixed)
+  const idx = Math.floor(Math.random() * missions.length);
+  randomMission.value = missions[idx];
+});
+
+async function startBoarding() {
   try {
     loading.value = true;
     errorMessage.value = "";
+    
     const res = await startQuiz({
       questionType: selectedQuestionType.value || undefined,
       sceneId: selectedSceneId.value || undefined
     });
+    
     quizStore.setStartOptions({
       questionType: selectedQuestionType.value,
       sceneId: selectedSceneId.value
     });
     quizStore.setCurrentAttempt(res.attemptId);
-    router.push(`/quiz/attempts/${res.attemptId}/questions/1`);
+    
+    isDeparting.value = true;
+    
+    // 1.5초의 이륙 시간 대기 
+    setTimeout(() => {
+      router.push(`/quiz/attempts/${res.attemptId}/questions/1`);
+    }, 1500);
+
   } catch (error) {
+    loading.value = false;
     const status = error?.response?.status;
     const code = error?.response?.data?.code;
-    if (status === 400) {
-      errorMessage.value = "퀴즈를 시작할 수 없습니다. 잠시 후 다시 시도해 주세요.";
-      return;
-    }
-    if (status === 401) {
-      errorMessage.value = "인증 상태가 만료되었습니다. 다시 로그인해 주세요.";
-      return;
-    }
-    if (status === 403) {
-      if (code === "GUEST_QUIZ_LIMIT_EXCEEDED") {
-        errorMessage.value = "비회원은 1회만 풀 수 있습니다. 로그인 후 계속 이용해 주세요.";
-        return;
-      }
-      errorMessage.value = "해당 요청에 대한 권한이 없습니다.";
-      return;
-    }
-    if (status === 404) {
-      errorMessage.value = "요청한 경로를 찾을 수 없습니다.";
-      return;
-    }
-    errorMessage.value = "퀴즈 시작 중 오류가 발생했습니다.";
-  } finally {
-    loading.value = false;
+    
+    if (status === 400) errorMessage.value = "이용할 수 없는 노선입니다.";
+    else if (status === 401) errorMessage.value = "여권 등 인증이 만료되었습니다. 다시 로그인해 주세요.";
+    else if (status === 403 && code === "GUEST_QUIZ_LIMIT_EXCEEDED") errorMessage.value = "여행 제한 구역입니다. 로그인 후 입장해주세요.";
+    else if (status === 403) errorMessage.value = "접근 권한이 없습니다.";
+    else if (status === 404) errorMessage.value = "게이트를 찾을 수 없습니다.";
+    else errorMessage.value = "시스템 지연으로 출발 대기 중입니다.";
   }
 }
 </script>
+
+<style scoped>
+/* ── 공항 보딩 패스 느낌 극대화 ── */
+.boarding-page {
+  /* 글로벌 App.vue 헤더를 덮어버리는 효과를 주기 위해 화면 전체 고정 */
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  z-index: 1000; /* 네비게이션 무시 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #0f172a; /* 공항 밤하늘 네이비 */
+  padding: 24px;
+  overflow-y: auto;
+  font-family: Pretendard, "Noto Sans KR", sans-serif;
+}
+
+/* 단순화된 전용 헤더 (글로벌 덮음) */
+.airport-header {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  padding: 24px 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 10;
+}
+/* ── 비행기 이륙 애니메이션 오버레이 ── */
+.takeoff-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(15, 23, 42, 0);
+  pointer-events: none;
+  animation: bgFadeIn 1.5s ease-in forwards;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+@keyframes bgFadeIn {
+  0% { background: rgba(15, 23, 42, 0); }
+  50% { background: rgba(56, 189, 248, 0.4); } /* 구름층 파란 하늘 느낌 */
+  100% { background: #0f172a; } /* 완전 암전 후 넘어감 */
+}
+
+/* 비행기 본체 */
+.airplane {
+  position: absolute;
+  font-size: 120px;
+  color: #fff;
+  transform: translate(-100vw, 100vh) rotate(45deg);
+  animation: flyoff 1.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  filter: drop-shadow(0 10px 20px rgba(0,0,0,0.5));
+}
+
+@keyframes flyoff {
+  0% { transform: translate(-100vw, 60vh) rotate(35deg) scale(0.5); opacity: 0; }
+  30% { opacity: 1; transform: translate(-40vw, 20vh) rotate(40deg) scale(0.8); }
+  100% { transform: translate(100vw, -80vh) rotate(45deg) scale(1.5); opacity: 0; }
+}
+
+/* 구름 효과 */
+.clouds-fx {
+  position: absolute;
+  font-size: 200px;
+  color: rgba(255,255,255,0.2);
+  transform: scale(3);
+  opacity: 0;
+  animation: cloudZoom 1s ease-out 0.3s forwards;
+  filter: blur(8px);
+}
+
+@keyframes cloudZoom {
+  0% { transform: scale(3) translateY(20%); opacity: 0; }
+  50% { opacity: 1; }
+  100% { transform: scale(8) translateY(-20%); opacity: 0; }
+}
+
+
+/* ── 비행기 티켓/디스플레이 하이브리드 카드 ── */
+.ticket-card {
+  width: min(440px, 100%);
+  background: #1e293b;
+  border-radius: 16px;
+  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 10;
+  overflow: hidden;
+  animation: ticketIn 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes ticketIn {
+  0% { opacity: 0; transform: translateY(40px) scale(0.95); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* 상단 타이틀 영역 (시각적 분리) */
+.ticket-top {
+  background: #0f172a;
+  padding: 32px 24px 24px 24px;
+  text-align: center;
+  border-bottom: 2px dashed #475569;
+  position: relative;
+}
+/* 티켓 잘린 느낌의 좌우 반원 홈 */
+.ticket-top::before, .ticket-top::after {
+  content: ''; position: absolute; bottom: -12px;
+  width: 24px; height: 24px; background: #0f172a; border-radius: 50%;
+}
+.ticket-top::before { left: -12px; }
+.ticket-top::after { right: -12px; }
+
+.gate-title {
+  font-size: 28px;
+  font-weight: 900;
+  color: #f8fafc;
+  letter-spacing: 6px;
+  margin: 0;
+  line-height: 1.1;
+  font-family: ui-monospace, monospace;
+}
+.gate-subtitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: #38bdf8;
+  margin-top: 8px;
+  letter-spacing: 2px;
+}
+
+
+/* 본문 (정보 및 미션 영역) */
+.ticket-middle {
+  padding: 32px 32px 24px;
+  background: #1e293b;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* 6️⃣ 문제 수 고정 -> 10을 거대하게 하이라이트 */
+.question-count-block {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+.q-num {
+  font-size: 80px;
+  font-weight: 900;
+  line-height: 1;
+  color: #fca5a5; /* 티켓의 붉은 스탬프 포인트 느낌 */
+  text-shadow: 0 4px 20px rgba(248, 113, 113, 0.2);
+  font-family: ui-monospace, sans-serif;
+}
+.q-text {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: 4px;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+/* 카드식 정보 그리드 */
+.flight-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 20px;
+  column-gap: 16px;
+}
+.full-width { grid-column: 1 / -1; }
+.info-item { display: flex; flex-direction: column; gap: 6px; }
+
+.i-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+.i-value {
+  font-size: 16px;
+  font-weight: 700;
+  color: #f1f5f9;
+}
+.time-val { color: #cbd5e1; font-weight: 500; }
+.highlight { color: #fca5a5; font-size: 18px; }
+
+.dotted-line {
+  border-top: 2px dotted #334155;
+  width: 100%;
+}
+
+/* 4️⃣ 오늘의 미션 박스화 강조 */
+.mission-box {
+  background: rgba(56, 189, 248, 0.05);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+.m-badge {
+  display: inline-block;
+  background: #0f172a;
+  color: #38bdf8;
+  font-size: 11px;
+  font-weight: 800;
+  padding: 4px 10px;
+  border-radius: 12px;
+  margin-bottom: 12px;
+  letter-spacing: 1px;
+}
+.m-text {
+  font-size: 20px;
+  font-weight: 700;
+  color: #f8fafc;
+  line-height: 1.4;
+  word-break: keep-all;
+}
+
+.error-msg {
+  color: #fca5a5; font-size: 13px; text-align: center; font-weight: 600;
+}
+
+
+/* 5️⃣ 강렬한 CTA 구역 (하단 분리형) */
+.ticket-bottom {
+  background: #0f172a;
+  padding: 24px 32px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.depart-btn {
+  width: 100%;
+  background: #fca5a5; /* 빨간색 포인트 유지 */
+  color: #0f172a;
+  border: none;
+  padding: 20px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 8px 16px rgba(248, 113, 113, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.btn-text-group { 
+  display: flex; 
+  flex-direction: column; 
+  align-items: center; 
+  justify-content: center;
+  gap: 4px;
+}
+.btn-main { 
+  font-size: 20px; 
+  font-weight: 900; 
+  letter-spacing: 1px; 
+  white-space: nowrap; /* 줄바꿈 방지 */
+}
+.btn-sub { 
+  font-size: 12px; 
+  font-weight: 800; 
+  letter-spacing: 3px; 
+  opacity: 0.8; 
+  white-space: nowrap; /* 줄바꿈 방지 */
+}
+
+.depart-btn:hover:not(:disabled) {
+  background: #fecaca;
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 12px 24px rgba(248, 113, 113, 0.25);
+}
+.depart-btn:active:not(:disabled) {
+  transform: translateY(2px) scale(0.98);
+}
+.depart-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.btn-loader {
+  width: 24px; height: 24px; border: 3px solid rgba(15, 23, 42, 0.2);
+  border-top-color: #0f172a; border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.footer-wish {
+  font-size: 13px;
+  font-weight: 600;
+  color: #475569;
+  margin-top: 20px;
+  letter-spacing: 1px;
+}
+
+/* 반응형 모바일 */
+@media (max-width: 600px) {
+  .airport-header { padding: 16px 20px; }
+  .boarding-page { padding: 80px 16px 24px; justify-content: flex-start; }
+  .ticket-card { margin-top: 20px; }
+  .ticket-top { padding: 24px 20px 16px; }
+  .gate-title { font-size: 24px; }
+  .ticket-middle { padding: 24px 20px; }
+  .q-num { font-size: 64px; }
+  .m-text { font-size: 18px; }
+  .ticket-bottom { padding: 20px 24px 24px; }
+  .btn-main { font-size: 18px; }
+}
+</style>


### PR DESCRIPTION
  ## 담당/리뷰
  - 담당자(Owner): @zkfmak9257
  - 리뷰어(Reviewer): @wjdqudwls

  ## 목적
  - 로그인 이후 학습 흐름을 “여행 시작” 경험으로 통일하기 위해 핵심 화면 UI/UX를 리디자인했습니다.
  - 단순 기능 화면이 아닌 브랜드 몰입형 흐름(메인 -> 출발 게이트 -> 퀴즈 -> 기록)을 강화했습니다.

  ## 변경 파일
  - `frontend/src/views/LoginView.vue`
  - `frontend/src/views/MainView.vue`
  - `frontend/src/views/QuizStartView.vue`
  - `frontend/src/views/MyPageView.vue`
  - `frontend/src/views/FavoriteListView.vue`

  ## 주요 변경 사항
  - 로그인 화면: Passport Theme 톤으로 브랜딩 정렬, 상호작용 피드백 정리
  - 메인 화면: 여행 컨셉 히어로/CTA(Call To Action, 행동 유도) 강화
  - 퀴즈 시작 화면: 중간 확인 화면 -> Boarding Gate(출발 게이트) 경험으로 재구성
  - 마이페이지: 여행 기록/진행도 중심 정보 구조로 재배치
  - 즐겨찾기: 스탬프 컬렉션 컨셉 기반 시각 구조 및 액션 영역 정리

  ## 사용자 흐름
  - 메인에서 모드/상황 선택
  - 출발 게이트에서 선택 정보와 미션 확인
  - `✈ 탑승 시작하기`로 퀴즈 진입
  - 학습 결과를 마이페이지/즐겨찾기에서 여행 기록처럼 확인

  ## 테스트 체크리스트
  - [ ] 각 화면 진입/렌더링 정상 동작 확인
  - [ ] CTA 클릭 시 라우팅 및 상태 전환 확인
  - [ ] 로그인/퀴즈 시작 실패 시 오류 메시지 노출 확인
  - [ ] 키보드 탭 이동/엔터 제출/포커스 접근성 확인
  - [ ] 모바일/데스크톱 반응형 레이아웃 확인

  ## API / DB 영향
  - API: 기존 API 재사용(구조 변경 없음)
  - DB: 변경 없음

  ## 리스크/확인 필요
  - 출발 게이트 전환 시간(애니메이션 길이) 사용자 체감 검토
  - 고정형/풀스크린 레이아웃이 기존 헤더/내비게이션과 충돌 없는지 점검